### PR TITLE
Avoid party validation when getting current user's party

### DIFF
--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -49,7 +49,6 @@ namespace Altinn.Register.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Party>> Get(int partyId)
         {
-            Console.WriteLine("Inside get party");
             if (!IsOrg(HttpContext))
             {
                 int? userId = GetUserId(HttpContext);
@@ -131,9 +130,7 @@ namespace Altinn.Register.Controllers
         /// </summary>
         private bool PartyIsCallingUser(int partyId)
         {
-            Console.WriteLine("Inside PartyIsCallingUser");
             string partyIdFromClaim = HttpContext.User.Claims.First(claim => claim.Type.Equals(AltinnCoreClaimTypes.PartyID))?.Value;
-            Console.WriteLine("Inside PartyIsCallingUser: " + partyIdFromClaim + ", " + partyId);
             return partyIdFromClaim != null ? int.Parse(partyIdFromClaim) == partyId : false;
         }
 

--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -49,6 +49,7 @@ namespace Altinn.Register.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Party>> Get(int partyId)
         {
+            Console.WriteLine("Inside get party");
             if (!IsOrg(HttpContext))
             {
                 int? userId = GetUserId(HttpContext);
@@ -130,7 +131,9 @@ namespace Altinn.Register.Controllers
         /// </summary>
         private bool PartyIsCallingUser(int partyId)
         {
+            Console.WriteLine("Inside PartyIsCallingUser");
             string partyIdFromClaim = HttpContext.User.Claims.First(claim => claim.Type.Equals(AltinnCoreClaimTypes.PartyID))?.Value;
+            Console.WriteLine("Inside PartyIsCallingUser: " + partyIdFromClaim + ", " + partyId);
             return partyIdFromClaim != null ? int.Parse(partyIdFromClaim) == partyId : false;
         }
 

--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -55,7 +55,11 @@ namespace Altinn.Register.Controllers
                 bool? isValid = false;
                 if (userId.HasValue)
                 {
-                    isValid = await _authorization.ValidateSelectedParty(userId.Value, partyId);
+                    isValid = PartyIsCallingUser(partyId);
+                    if ((bool)!isValid)
+                    {
+                        isValid = await _authorization.ValidateSelectedParty(userId.Value, partyId);
+                    }
                 }
 
                 if (!isValid.HasValue || !isValid.Value)
@@ -119,6 +123,15 @@ namespace Altinn.Register.Controllers
             }
 
             return Ok(parties);
+        }
+
+        /// <summary>
+        /// Check whether the party id is the user's party id
+        /// </summary>
+        private bool PartyIsCallingUser(int partyId)
+        {
+            string partyIdFromClaim = HttpContext.User.Claims.First(claim => claim.Type.Equals(AltinnCoreClaimTypes.PartyID))?.Value;
+            return partyIdFromClaim != null ? int.Parse(partyIdFromClaim) == partyId : false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Avoid expensive authorization call to validate party (involving fetching the user's party list) when serving a party request for the current user.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
