### PR TITLE
Changed path to GetPartyByUuid as APIM deploy failed

### DIFF
--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -83,13 +83,13 @@ namespace Altinn.Register.Controllers
         /// </summary>
         /// <param name="partyUuid">The party uuid.</param>
         /// <returns>The information about a given party.</returns>
-        [HttpGet("{partyUuid:Guid}")]
+        [HttpGet("")]
         [ProducesResponseType(404)]
         [ProducesResponseType(401)]
         [ProducesResponseType(200)]
         [Produces("application/json")]
         [Authorize]
-        public async Task<ActionResult<Party>> GetByUuid(Guid partyUuid)
+        public async Task<ActionResult<Party>> GetByUuid([FromQuery] Guid partyUuid)
         {
             Party party = await _partiesWrapper.GetPartyByUuid(partyUuid);
 
@@ -152,15 +152,16 @@ namespace Altinn.Register.Controllers
         /// Gets the party list for the list of party ids.
         /// </summary>
         /// <param name="partyIds">List of partyIds for parties to retrieve.</param>
+        /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
         /// <returns>List of parties based on the partyIds.</returns>
         [HttpPost("partylist")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<ActionResult<List<Party>>> GetPartyListForPartyIds([FromBody] List<int> partyIds)
+        public async Task<ActionResult<List<Party>>> GetPartyListForPartyIds([FromBody] List<int> partyIds, [FromQuery] bool fetchSubUnits = false)
         {
             List<Party> parties;
 
-            parties = await _partiesWrapper.GetPartyList(partyIds);
+            parties = await _partiesWrapper.GetPartyList(partyIds, fetchSubUnits);
 
             if (parties == null || parties.Count < 1)
             {
@@ -174,13 +175,14 @@ namespace Altinn.Register.Controllers
         /// Gets the party list for the list of party uuids.
         /// </summary>
         /// <param name="partyUuids">List of partyUuids for parties to retrieve.</param>
+        /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
         /// <returns>List of parties based on the party uuids.</returns>
         [HttpPost("partylistbyuuid")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<ActionResult<List<Party>>> GetPartyListForPartyUuids([FromBody] List<Guid> partyUuids)
+        public async Task<ActionResult<List<Party>>> GetPartyListForPartyUuids([FromBody] List<Guid> partyUuids, [FromQuery] bool fetchSubUnits = false)
         {
-            List<Party> parties = await _partiesWrapper.GetPartyListByUuid(partyUuids);
+            List<Party> parties = await _partiesWrapper.GetPartyListByUuid(partyUuids, fetchSubUnits);
             return Ok(parties);
         }
 

--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -89,7 +89,7 @@ namespace Altinn.Register.Controllers
         [ProducesResponseType(200)]
         [Produces("application/json")]
         [Authorize]
-        public async Task<ActionResult<Party>> GetByUuid(Guid partyUuid)
+        public async Task<ActionResult<Party>> GetByUuid([FromRoute] Guid partyUuid)
         {
             Party party = await _partiesWrapper.GetPartyByUuid(partyUuid);
 

--- a/src/Controllers/PartiesController.cs
+++ b/src/Controllers/PartiesController.cs
@@ -83,13 +83,13 @@ namespace Altinn.Register.Controllers
         /// </summary>
         /// <param name="partyUuid">The party uuid.</param>
         /// <returns>The information about a given party.</returns>
-        [HttpGet("")]
+        [HttpGet("byuuid/{partyUuid:Guid}")]
         [ProducesResponseType(404)]
         [ProducesResponseType(401)]
         [ProducesResponseType(200)]
         [Produces("application/json")]
         [Authorize]
-        public async Task<ActionResult<Party>> GetByUuid([FromQuery] Guid partyUuid)
+        public async Task<ActionResult<Party>> GetByUuid(Guid partyUuid)
         {
             Party party = await _partiesWrapper.GetPartyByUuid(partyUuid);
 

--- a/src/Services/Implementation/PartiesWrapper.cs
+++ b/src/Services/Implementation/PartiesWrapper.cs
@@ -96,9 +96,9 @@ public class PartiesWrapper : IParties
     }
 
     /// <inheritdoc />
-    public async Task<List<Party>> GetPartyList(List<int> partyIds)
+    public async Task<List<Party>> GetPartyList(List<int> partyIds, bool fetchSubUnits = false)
     {
-        UriBuilder uriBuilder = new UriBuilder($"{_generalSettings.BridgeApiEndpoint}parties");
+        UriBuilder uriBuilder = new UriBuilder($"{_generalSettings.BridgeApiEndpoint}parties?fetchSubUnits={fetchSubUnits}");
 
         StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
         HttpResponseMessage response = await _client.PostAsync(uriBuilder.Uri, requestBody);
@@ -142,9 +142,9 @@ public class PartiesWrapper : IParties
     }
 
     /// <inheritdoc />
-    public async Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids)
+    public async Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids, bool fetchSubUnits = false)
     {
-        UriBuilder uriBuilder = new UriBuilder($"{_generalSettings.BridgeApiEndpoint}parties/byuuid");
+        UriBuilder uriBuilder = new UriBuilder($"{_generalSettings.BridgeApiEndpoint}parties/byuuid?fetchSubUnits={fetchSubUnits}");
 
         StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyUuids), Encoding.UTF8, "application/json");
         HttpResponseMessage response = await _client.PostAsync(uriBuilder.Uri, requestBody);

--- a/src/Services/Interfaces/IParties.cs
+++ b/src/Services/Interfaces/IParties.cs
@@ -36,13 +36,15 @@ public interface IParties
     /// Returns a list of Parties based on a list of partyIds.
     /// </summary>
     /// <param name="partyIds">List of partyIds.</param>
+    /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
     /// <returns>A list of Parties.</returns>
-    Task<List<Party>> GetPartyList(List<int> partyIds);
+    Task<List<Party>> GetPartyList(List<int> partyIds, bool fetchSubUnits);
 
     /// <summary>
     /// Returns a list of Parties based on a list of party uuids.
     /// </summary>
     /// <param name="partyUuids">List of party uuids.</param>
+    /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
     /// <returns>A list of Parties.</returns>
-    Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids);
+    Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids, bool fetchSubUnits);
 }

--- a/src/Services/Interfaces/IParties.cs
+++ b/src/Services/Interfaces/IParties.cs
@@ -38,7 +38,7 @@ public interface IParties
     /// <param name="partyIds">List of partyIds.</param>
     /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
     /// <returns>A list of Parties.</returns>
-    Task<List<Party>> GetPartyList(List<int> partyIds, bool fetchSubUnits);
+    Task<List<Party>> GetPartyList(List<int> partyIds, bool fetchSubUnits = false);
 
     /// <summary>
     /// Returns a list of Parties based on a list of party uuids.
@@ -46,5 +46,5 @@ public interface IParties
     /// <param name="partyUuids">List of party uuids.</param>
     /// <param name="fetchSubUnits">flag indicating whether subunits should be included</param>
     /// <returns>A list of Parties.</returns>
-    Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids, bool fetchSubUnits);
+    Task<List<Party>> GetPartyListByUuid(List<Guid> partyUuids, bool fetchSubUnits = false);
 }

--- a/test/Testdata/50004216.json
+++ b/test/Testdata/50004216.json
@@ -20,6 +20,7 @@
     "BusinessPostalCity": ""
   },
   "PartyId": 50004216,
+  "PartyUuid": "7aa53da8-836c-4812-afcb-76d39f5ebb0e",
   "UnitType": "ANS",
   "Name": "TYNSET OG OPPDAL",
   "IsDeleted": false,

--- a/test/Testdata/50004219.json
+++ b/test/Testdata/50004219.json
@@ -20,6 +20,7 @@
     "BusinessPostalCity": null
   },
   "PartyId": 50004219,
+  "PartyUuid": "d0c063a2-9cb3-4724-9d47-e44cec590d2c",
   "UnitType": "AS",
   "Name": "KOLSAAS OG FLAAM",
   "IsDeleted": true,

--- a/test/TestingControllers/PartiesControllerTests.cs
+++ b/test/TestingControllers/PartiesControllerTests.cs
@@ -261,7 +261,7 @@ namespace Altinn.Register.Tests.TestingControllers
         [Fact]
         public async Task GetPartyListByUuid_SameLengthRequestAsResponse_ReturnsPartyList()
         {
-            List<Guid> partyUuids = new List<Guid> { new("93630D41-CA61-4B5C-B8FB-3346B561F6FF"), new("E622554E-3DE5-44CD-A822-C66024768013") };
+            List<Guid> partyUuids = new List<Guid> { new("93630d41-ca61-4b5c-b8fb-3346b561f6ff"), new("e622554e-3de5-44cd-a822-c66024768013") };
 
             // Arrange
             Mock<IParties> partiesService = new Mock<IParties>();
@@ -291,7 +291,7 @@ namespace Altinn.Register.Tests.TestingControllers
         [Fact]
         public async Task GetPartyListByUuid_FetchSubUnitsSetToTrue_ReturnsPartyList()
         {
-            List<Guid> partyUuids = new List<Guid> { new("93630D41-CA61-4B5C-B8FB-3346B561F6FF"), new("E622554E-3DE5-44CD-A822-C66024768013") };
+            List<Guid> partyUuids = new List<Guid> { new("93630d41-ca61-4b5c-b8fb-3346b561f6ff"), new("e622554e-3de5-44cd-a822-c66024768013") };
 
             // Arrange
             Mock<IParties> partiesService = new Mock<IParties>();
@@ -325,12 +325,12 @@ namespace Altinn.Register.Tests.TestingControllers
             string token = PrincipalUtil.GetToken(1);
 
             Mock<IParties> partiesService = new Mock<IParties>();
-            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630D41-CA61-4B5C-B8FB-3346B561F6FF")))).ReturnsAsync(new Party());
+            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630d41-ca61-4b5c-b8fb-3346b561f6ff")))).ReturnsAsync(new Party());
 
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/byuuid/93630d41-ca61-4b5c-b8fb-3346b561f6ff");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -353,12 +353,12 @@ namespace Altinn.Register.Tests.TestingControllers
             string token = PrincipalUtil.GetToken(1);
 
             Mock<IParties> partiesService = new Mock<IParties>();
-            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630D41-CA61-4B5C-B8FB-3346B561F6FF")))).ReturnsAsync((Party)null);
+            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630d41-ca61-4b5c-b8fb-3346b561f6ff")))).ReturnsAsync((Party)null);
 
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/byuuid/93630d41-ca61-4b5c-b8fb-3346b561f6ff");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -381,7 +381,7 @@ namespace Altinn.Register.Tests.TestingControllers
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/byuuid/93630d41-ca61-4b5c-b8fb-3346b561f6ff");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -400,12 +400,12 @@ namespace Altinn.Register.Tests.TestingControllers
             string token = PrincipalUtil.GetServiceOwnerOrgToken("ttd");
 
             Mock<IParties> partiesService = new Mock<IParties>();
-            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630D41-CA61-4B5C-B8FB-3346B561F6FF")))).ReturnsAsync((Party)null);
+            partiesService.Setup(s => s.GetPartyByUuid(It.Is<Guid>(g => g == new Guid("93630d41-ca61-4b5c-b8fb-3346b561f6ff")))).ReturnsAsync((Party)null);
 
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/byuuid/93630d41-ca61-4b5c-b8fb-3346b561f6ff");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -420,7 +420,7 @@ namespace Altinn.Register.Tests.TestingControllers
         [Fact]
         public async Task GetPartyListByUuid_NoResponse_ReturnsEmptyList()
         {
-            List<Guid> partyUuids = new List<Guid> { new("93630D41-CA61-4B5C-B8FB-3346B561F6FF"), new("E622554E-3DE5-44CD-A822-C66024768013") };
+            List<Guid> partyUuids = new List<Guid> { new("93630d41-ca61-4b5c-b8fb-3346b561f6ff"), new("e622554e-3de5-44cd-a822-c66024768013") };
 
             // Arrange
             Mock<IParties> partiesService = new Mock<IParties>();

--- a/test/TestingControllers/PartiesControllerTests.cs
+++ b/test/TestingControllers/PartiesControllerTests.cs
@@ -199,13 +199,73 @@ namespace Altinn.Register.Tests.TestingControllers
         }
 
         [Fact]
+        public async Task GetPartyListById_SameLengthRequestAsResponse_ReturnsPartyList()
+        {
+            List<int> partyIds = new List<int> { 1, 2 };
+
+            // Arrange
+            Mock<IParties> partiesService = new Mock<IParties>();
+            partiesService.Setup(s => s.GetPartyList(It.IsAny<List<int>>(), It.Is<bool>(b => b == false))).ReturnsAsync(new List<Party> { new(), new() });
+
+            HttpClient client = GetTestClient(partiesService.Object);
+
+            StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/register/api/v1/parties/partylist") { Content = requestBody };
+            httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            partiesService.VerifyAll();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            List<Party> actual = await JsonSerializer.DeserializeAsync<List<Party>>(await response.Content.ReadAsStreamAsync());
+
+            Assert.NotNull(actual);
+            Assert.Equal(partyIds.Count, actual.Count);
+        }
+
+        [Fact]
+        public async Task GetPartyListById_FetchSubUnitsTrue_ReturnsPartyList()
+        {
+            List<int> partyIds = new List<int> { 1, 2 };
+
+            // Arrange
+            Mock<IParties> partiesService = new Mock<IParties>();
+            partiesService.Setup(s => s.GetPartyList(It.IsAny<List<int>>(), It.Is<bool>(b => b == true))).ReturnsAsync(new List<Party> { new(), new() });
+
+            HttpClient client = GetTestClient(partiesService.Object);
+
+            StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/register/api/v1/parties/partylist?fetchSubUnits=true") { Content = requestBody };
+            httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            partiesService.VerifyAll();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            List<Party> actual = await JsonSerializer.DeserializeAsync<List<Party>>(await response.Content.ReadAsStreamAsync());
+
+            Assert.NotNull(actual);
+            Assert.Equal(partyIds.Count, actual.Count);
+        }
+
+        [Fact]
         public async Task GetPartyListByUuid_SameLengthRequestAsResponse_ReturnsPartyList()
         {
             List<Guid> partyUuids = new List<Guid> { new("93630D41-CA61-4B5C-B8FB-3346B561F6FF"), new("E622554E-3DE5-44CD-A822-C66024768013") };
 
             // Arrange
             Mock<IParties> partiesService = new Mock<IParties>();
-            partiesService.Setup(s => s.GetPartyListByUuid(It.IsAny<List<Guid>>())).ReturnsAsync(new List<Party> { new(), new() });
+            partiesService.Setup(s => s.GetPartyListByUuid(It.IsAny<List<Guid>>(), It.Is<bool>(b => b == false))).ReturnsAsync(new List<Party> { new(), new() });
 
             HttpClient client = GetTestClient(partiesService.Object);
 
@@ -229,6 +289,36 @@ namespace Altinn.Register.Tests.TestingControllers
         }
 
         [Fact]
+        public async Task GetPartyListByUuid_FetchSubUnitsSetToTrue_ReturnsPartyList()
+        {
+            List<Guid> partyUuids = new List<Guid> { new("93630D41-CA61-4B5C-B8FB-3346B561F6FF"), new("E622554E-3DE5-44CD-A822-C66024768013") };
+
+            // Arrange
+            Mock<IParties> partiesService = new Mock<IParties>();
+            partiesService.Setup(s => s.GetPartyListByUuid(It.IsAny<List<Guid>>(), It.Is<bool>(b => b == true))).ReturnsAsync(new List<Party> { new(), new() });
+
+            HttpClient client = GetTestClient(partiesService.Object);
+
+            StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyUuids), Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "/register/api/v1/parties/partylistbyuuid?fetchsubunits=true") { Content = requestBody };
+            httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            // Assert
+            partiesService.VerifyAll();
+            
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            List<Party> actual = await JsonSerializer.DeserializeAsync<List<Party>>(await response.Content.ReadAsStreamAsync());
+
+            Assert.NotNull(actual);
+            Assert.Equal(partyUuids.Count, actual.Count);
+        }
+
+        [Fact]
         public async Task GetPartyByUuid_FetchParty_ReturnsParty()
         {
             // Arrange
@@ -240,7 +330,7 @@ namespace Altinn.Register.Tests.TestingControllers
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -268,7 +358,7 @@ namespace Altinn.Register.Tests.TestingControllers
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -291,7 +381,7 @@ namespace Altinn.Register.Tests.TestingControllers
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -315,7 +405,7 @@ namespace Altinn.Register.Tests.TestingControllers
             HttpClient client = GetTestClient(partiesService.Object);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties/93630D41-CA61-4B5C-B8FB-3346B561F6FF");
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/register/api/v1/parties?partyuuid=93630D41-CA61-4B5C-B8FB-3346B561F6FF");
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
             // Act
@@ -334,7 +424,7 @@ namespace Altinn.Register.Tests.TestingControllers
 
             // Arrange
             Mock<IParties> partiesService = new Mock<IParties>();
-            partiesService.Setup(s => s.GetPartyListByUuid(It.IsAny<List<Guid>>())).ReturnsAsync(new List<Party>());
+            partiesService.Setup(s => s.GetPartyListByUuid(It.IsAny<List<Guid>>(), It.Is<bool>(b => b == false))).ReturnsAsync(new List<Party>());
 
             HttpClient client = GetTestClient(partiesService.Object);
 

--- a/test/UnitTests/PartyWrapperTest.cs
+++ b/test/UnitTests/PartyWrapperTest.cs
@@ -201,7 +201,7 @@ namespace Altinn.Register.Tests.UnitTests
 
             Assert.NotNull(sblRequest);
             Assert.Equal(HttpMethod.Post, sblRequest.Method);
-            Assert.EndsWith($"parties/byuuid", sblRequest.RequestUri!.ToString());
+            Assert.EndsWith($"parties/byuuid?fetchsubunits=false", sblRequest.RequestUri!.ToString().ToLower());
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace Altinn.Register.Tests.UnitTests
             
             Assert.NotNull(sblRequest);
             Assert.Equal(HttpMethod.Post, sblRequest.Method);
-            Assert.EndsWith($"parties/byuuid", sblRequest.RequestUri!.ToString());
+            Assert.EndsWith($"parties/byuuid?fetchsubunits=false", sblRequest.RequestUri!.ToString().ToLower());
         }
 
         private static async Task<HttpResponseMessage> CreateHttpResponseMessage(object obj)


### PR DESCRIPTION
Changed path to GetPartyByUuid as APIM deploy failed as they shared path but with difrent datatype on id but apim saw this as identical path but in swagger it worked fine.

Also added posibility to override the parameter fetchSubUnits exposed on SBLBridge for GetPartyList and GetPartyListByUuid.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #154 
- #164 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
