### PR TITLE
chore: cleanup Altinn.Platform.Models

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageVersion Include="Altinn.Common.AccessToken" Version="4.4.3" />
     <PackageVersion Include="Altinn.Common.PEP" Version="4.0.0" />
-    <PackageVersion Include="Altinn.Platform.Models" Version="1.6.1" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
@@ -23,7 +22,6 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="MinVer" Version="5.0.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />

--- a/src/Altinn.Platform.Models/Directory.Build.props
+++ b/src/Altinn.Platform.Models/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="../../Directory.Build.props" />
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Altinn.Platform.Models.csproj
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Altinn.Platform.Models.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.ComponentModel.Annotations" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Authorization/Models/Role.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Authorization/Models/Role.cs
@@ -1,25 +1,20 @@
-using System;
+using System.Diagnostics;
 
-using Newtonsoft.Json;
+namespace Authorization.Platform.Authorization.Models;
 
-namespace Authorization.Platform.Authorization.Models
+/// <summary>
+/// Entity representing a Role
+/// </summary>
+[DebuggerDisplay("{Value}", Name = "[{Type}]")]
+public record Role
 {
     /// <summary>
-    /// Entity representing a Role
+    /// Gets or sets the role type
     /// </summary>
-    [Serializable]
-    public class Role
-    {
-        /// <summary>
-        /// Gets or sets the role type
-        /// </summary>
-        [JsonProperty]
-        public string Type { get; set; }
+    public string? Type { get; set; }
 
-        /// <summary>
-        /// Gets or sets the role
-        /// </summary>
-        [JsonProperty]
-        public string Value { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the role
+    /// </summary>
+    public string? Value { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Enums/UserType.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Enums/UserType.cs
@@ -1,43 +1,42 @@
-namespace Altinn.Platform.Profile.Enums
+namespace Altinn.Platform.Profile.Enums;
+
+/// <summary>
+/// Enumeration for the available user types
+/// </summary>
+public enum UserType : int
 {
     /// <summary>
-    /// Enumeration for the available user types
+    /// User type has not been specified
     /// </summary>
-    public enum UserType : int
-    {
-        /// <summary>
-        /// User type has not been specified
-        /// </summary>
-        None = 0,
+    None = 0,
 
-        /// <summary>
-        /// User Type is SSN Identified User.
-        /// </summary>
-        SSNIdentified = 1,
+    /// <summary>
+    /// User Type is SSN Identified User.
+    /// </summary>
+    SSNIdentified = 1,
 
-        /// <summary>
-        /// User Type is Self Identified User.
-        /// </summary>
-        SelfIdentified = 2,
+    /// <summary>
+    /// User Type is Self Identified User.
+    /// </summary>
+    SelfIdentified = 2,
 
-        /// <summary>
-        /// User Type is EnterpriseIdentified Identified User.
-        /// </summary>
-        EnterpriseIdentified = 3,
+    /// <summary>
+    /// User Type is EnterpriseIdentified Identified User.
+    /// </summary>
+    EnterpriseIdentified = 3,
 
-        /// <summary>
-        /// User Type is Agency User
-        /// </summary>
-        AgencyUser = 4,
+    /// <summary>
+    /// User Type is Agency User
+    /// </summary>
+    AgencyUser = 4,
 
-        /// <summary>
-        /// User Type is PSAN User
-        /// </summary>
-        PSAN = 5,
+    /// <summary>
+    /// User Type is PSAN User
+    /// </summary>
+    PSAN = 5,
 
-        /// <summary>
-        /// User Type is PSA User
-        /// </summary>
-        PSA = 6
-    }
+    /// <summary>
+    /// User Type is PSA User
+    /// </summary>
+    PSA = 6,
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Models/ProfileSettingPreference.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Models/ProfileSettingPreference.cs
@@ -1,35 +1,40 @@
-namespace Altinn.Platform.Profile.Models
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Altinn.Platform.Profile.Models;
+
+/// <summary>
+/// Class describing a users profile setting preferences.
+/// </summary>
+public record ProfileSettingPreference
 {
     /// <summary>
-    /// Class describing a users profile setting preferences.
+    /// Sets the user's language preference in Altinn.
     /// </summary>
-    public class ProfileSettingPreference
+    /// <remarks>
+    /// Only here for historical reasons. Use <see cref="Language"/> instead.
+    /// </remarks>
+    [Obsolete("Use Language instead")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public string LanguageType
     {
-        /// <summary>
-        /// Sets the user's language preference in Altinn.
-        /// </summary>
-        public string LanguageType
-        {
-            set
-            {
-                Language = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the user's language preference in Altinn.
-        /// </summary>
-        public string Language { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user's preselected party.
-        /// </summary>
-        public int PreSelectedPartyId { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the users want
-        /// to be asked for the party on every form submission.
-        /// </summary>
-        public bool DoNotPromptForParty { get; set; }
+        set => Language = value;
     }
+
+    /// <summary>
+    /// Gets or sets the user's language preference in Altinn.
+    /// </summary>
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user's preselected party.
+    /// </summary>
+    public int PreSelectedPartyId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the users want
+    /// to be asked for the party on every form submission.
+    /// </summary>
+    public bool DoNotPromptForParty { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Models/UserProfile.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Profile/Models/UserProfile.cs
@@ -1,68 +1,65 @@
-using System;
-
 using Altinn.Platform.Profile.Enums;
 using Altinn.Platform.Register.Models;
 
-namespace Altinn.Platform.Profile.Models
+namespace Altinn.Platform.Profile.Models;
+
+/// <summary>
+/// Class describing a user profile
+/// </summary>
+public record UserProfile
 {
     /// <summary>
-    /// Class describing a user profile
+    /// Gets or sets the ID of the user
     /// </summary>
-    public class UserProfile
-    {
-        /// <summary>
-        /// Gets or sets the ID of the user
-        /// </summary>
-        public int UserId { get; set; }
+    public int UserId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the UUID of the user
-        /// </summary>
-        public Guid? UserUuid { get; set; }
+    /// <summary>
+    /// Gets or sets the UUID of the user
+    /// </summary>
+    public Guid? UserUuid { get; set; }
 
-        /// <summary>
-        /// Gets or sets the username
-        /// </summary>
-        public string UserName { get; set; }
+    /// <summary>
+    /// Gets or sets the username
+    /// </summary>
+    public string? UserName { get; set; }
 
-        /// <summary>
-        /// Gets or sets ExternalIdentity
-        /// </summary>
-        public string ExternalIdentity { get; set; }
+    /// <summary>
+    /// Gets or sets ExternalIdentity
+    /// </summary>
+    public string? ExternalIdentity { get; set; }
 
-        /// <summary>
-        /// Gets or sets a boolean indicating whether the user has reserved themselves from electronic communication
-        /// </summary>
-        public bool IsReserved { get; set; }
+    /// <summary>
+    /// Gets or sets a boolean indicating whether the user has reserved themselves from electronic communication
+    /// </summary>
+    public bool IsReserved { get; set; }
 
-        /// <summary>
-        /// Gets or sets the phone number
-        /// </summary>
-        public string PhoneNumber { get; set; }
+    /// <summary>
+    /// Gets or sets the phone number
+    /// </summary>
+    public string? PhoneNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email address
-        /// </summary>
-        public string Email { get; set; }
+    /// <summary>
+    /// Gets or sets the email address
+    /// </summary>
+    public string? Email { get; set; }
 
-        /// <summary>
-        /// Gets or sets the party ID
-        /// </summary>
-        public int PartyId { get; set; }
+    /// <summary>
+    /// Gets or sets the party ID
+    /// </summary>
+    public int PartyId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the <see cref="Party"/>
-        /// </summary>
-        public Party Party { get; set; }
+    /// <summary>
+    /// Gets or sets the <see cref="Party"/>
+    /// </summary>
+    public Party? Party { get; set; }
 
-        /// <summary>
-        /// Gets or sets the <see cref="UserType"/>
-        /// </summary>
-        public UserType UserType { get; set; }
+    /// <summary>
+    /// Gets or sets the <see cref="UserType"/>
+    /// </summary>
+    public UserType UserType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the <see cref="ProfileSettingPreference"/>
-        /// </summary>
-        public ProfileSettingPreference ProfileSettingPreference { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the <see cref="ProfileSettingPreference"/>
+    /// </summary>
+    public ProfileSettingPreference? ProfileSettingPreference { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Enums/PartyType.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Enums/PartyType.cs
@@ -1,33 +1,32 @@
-namespace Altinn.Platform.Register.Enums
+namespace Altinn.Platform.Register.Enums;
+
+/// <summary>
+/// Enum containing values for the different types of parties
+/// </summary>
+public enum PartyType
 {
     /// <summary>
-    /// Enum containing values for the different types of parties
+    /// Party Type is Person
     /// </summary>
-    public enum PartyType
-    {
-        /// <summary>
-        /// Party Type is Person
-        /// </summary>
-        Person = 1,
+    Person = 1,
 
-        /// <summary>
-        /// Party Type is Organization
-        /// </summary>
-        Organisation = 2,
+    /// <summary>
+    /// Party Type is Organization
+    /// </summary>
+    Organisation = 2,
 
-        /// <summary>
-        /// Party Type is Self Identified user
-        /// </summary>
-        SelfIdentified = 3,
+    /// <summary>
+    /// Party Type is Self Identified user
+    /// </summary>
+    SelfIdentified = 3,
 
-        /// <summary>
-        /// Party Type is sub unit
-        /// </summary>
-        SubUnit = 4,
+    /// <summary>
+    /// Party Type is sub unit
+    /// </summary>
+    SubUnit = 4,
 
-        /// <summary>
-        /// Party Type is bankruptcy estate
-        /// </summary>
-        BankruptcyEstate = 5
-    }
+    /// <summary>
+    /// Party Type is bankruptcy estate
+    /// </summary>
+    BankruptcyEstate = 5
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Organization.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Organization.cs
@@ -1,83 +1,82 @@
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Class representing an organization
+/// </summary>
+public record Organization
 {
     /// <summary>
-    /// Class representing an organization
+    /// Gets or sets the organization number
     /// </summary>
-    public class Organization
-    {
-        /// <summary>
-        /// Gets or sets the organization number
-        /// </summary>
-        public string OrgNumber { get; set; }
+    public string? OrgNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the organization
-        /// </summary>
-        public string Name { get; set; }
+    /// <summary>
+    /// Gets or sets the name of the organization
+    /// </summary>
+    public string? Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets the unit type
-        /// </summary>
-        public string UnitType { get; set; }
+    /// <summary>
+    /// Gets or sets the unit type
+    /// </summary>
+    public string? UnitType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the telephone number
-        /// </summary>
-        public string TelephoneNumber { get; set; }
+    /// <summary>
+    /// Gets or sets the telephone number
+    /// </summary>
+    public string? TelephoneNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mobile number
-        /// </summary>
-        public string MobileNumber { get; set; }
+    /// <summary>
+    /// Gets or sets the mobile number
+    /// </summary>
+    public string? MobileNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the fax number
-        /// </summary>
-        public string FaxNumber { get; set; }
+    /// <summary>
+    /// Gets or sets the fax number
+    /// </summary>
+    public string? FaxNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the eMail address
-        /// </summary>
-        public string EMailAddress { get; set; }
+    /// <summary>
+    /// Gets or sets the eMail address
+    /// </summary>
+    public string? EMailAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets the internet address
-        /// </summary>
-        public string InternetAddress { get; set; }
+    /// <summary>
+    /// Gets or sets the internet address
+    /// </summary>
+    public string? InternetAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mailing address
-        /// </summary>
-        public string MailingAddress { get; set; }
+    /// <summary>
+    /// Gets or sets the mailing address
+    /// </summary>
+    public string? MailingAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mailing postal code 
-        /// </summary>
-        public string MailingPostalCode { get; set; }
+    /// <summary>
+    /// Gets or sets the mailing postal code 
+    /// </summary>
+    public string? MailingPostalCode { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mailing postal city 
-        /// </summary>
-        public string MailingPostalCity { get; set; }
+    /// <summary>
+    /// Gets or sets the mailing postal city 
+    /// </summary>
+    public string? MailingPostalCity { get; set; }
 
-        /// <summary>
-        /// Gets or sets the business address
-        /// </summary>
-        public string BusinessAddress { get; set; }
+    /// <summary>
+    /// Gets or sets the business address
+    /// </summary>
+    public string? BusinessAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets the postal code business
-        /// </summary>
-        public string BusinessPostalCode { get; set; }
+    /// <summary>
+    /// Gets or sets the postal code business
+    /// </summary>
+    public string? BusinessPostalCode { get; set; }
 
-        /// <summary>
-        /// Gets or sets the postal city business
-        /// </summary>
-        public string BusinessPostalCity { get; set; }
+    /// <summary>
+    /// Gets or sets the postal city business
+    /// </summary>
+    public string? BusinessPostalCity { get; set; }
 
-        /// <summary>
-        /// Gets or sets the unit status
-        /// </summary>
-        public string UnitStatus { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the unit status
+    /// </summary>
+    public string? UnitStatus { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Party.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Party.cs
@@ -1,73 +1,69 @@
-using System;
-using System.Collections.Generic;
-
 using Altinn.Platform.Register.Enums;
 
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Class representing a party
+/// </summary>
+public record Party
 {
     /// <summary>
-    /// Class representing a party
+    /// Gets or sets the ID of the party
     /// </summary>
-    public class Party
-    {
-        /// <summary>
-        /// Gets or sets the ID of the party
-        /// </summary>
-        public int PartyId { get; set; }
+    public int PartyId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the UUID of the party
-        /// </summary>
-        public Guid? PartyUuid { get; set; }
+    /// <summary>
+    /// Gets or sets the UUID of the party
+    /// </summary>
+    public Guid? PartyUuid { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of party
-        /// </summary>
-        public PartyType PartyTypeName { get; set; }
+    /// <summary>
+    /// Gets or sets the type of party
+    /// </summary>
+    public PartyType PartyTypeName { get; set; }
 
-        /// <summary>
-        /// Gets the parties org number
-        /// </summary>
-        public string OrgNumber { get; set; }
+    /// <summary>
+    /// Gets the parties org number
+    /// </summary>
+    public string? OrgNumber { get; set; }
 
-        /// <summary>
-        /// Gets the parties ssn
-        /// </summary>
-        public string SSN { get; set; }
+    /// <summary>
+    /// Gets the parties ssn
+    /// </summary>
+    public string? SSN { get; set; }
 
-        /// <summary>
-        /// Gets or sets the UnitType
-        /// </summary>
-        public string UnitType { get; set; }
+    /// <summary>
+    /// Gets or sets the UnitType
+    /// </summary>
+    public string? UnitType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the Name
-        /// </summary>
-        public string Name { get; set; }
+    /// <summary>
+    /// Gets or sets the Name
+    /// </summary>
+    public string? Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets the IsDeleted
-        /// </summary>
-        public bool IsDeleted { get; set; }
+    /// <summary>
+    /// Gets or sets the IsDeleted
+    /// </summary>
+    public bool IsDeleted { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether if the reportee in the list is only there for showing the hierarchy (a parent unit with no access)
-        /// </summary>
-        public bool OnlyHierarchyElementWithNoAccess { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether if the reportee in the list is only there for showing the hierarchy (a parent unit with no access)
+    /// </summary>
+    public bool OnlyHierarchyElementWithNoAccess { get; set; }
 
-        /// <summary>
-        /// Gets or sets the person details for this party (will only be set if the party type is Person)
-        /// </summary>
-        public Person Person { get; set; }
+    /// <summary>
+    /// Gets or sets the person details for this party (will only be set if the party type is Person)
+    /// </summary>
+    public Person? Person { get; set; }
 
-        /// <summary>
-        /// Gets or sets the organization details for this party (will only be set if the party type is Organization)
-        /// </summary>
-        public Organization Organization { get; set; }
+    /// <summary>
+    /// Gets or sets the organization details for this party (will only be set if the party type is Organization)
+    /// </summary>
+    public Organization? Organization { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value of ChildParties
-        /// </summary>
-        public List<Party> ChildParties { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the value of ChildParties
+    /// </summary>
+    public IReadOnlyList<Party>? ChildParties { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyLookup.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyLookup.cs
@@ -1,51 +1,53 @@
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Represents a lookup criteria when looking for a Party. Only one of the properties can be used at a time.
+/// If none or more than one property have a value the lookup operation will respond with bad request.
+/// </summary>
+public record PartyLookup 
+    : IValidatableObject
 {
     /// <summary>
-    /// Represents a lookup criteria when looking for a Party. Only one of the properties can be used at a time.
-    /// If none or more than one property have a value the lookup operation will respond with bad request.
+    /// Gets or sets the social security number of the party to look for.
     /// </summary>
-    public class PartyLookup : IValidatableObject
+    [JsonPropertyName("ssn")]
+    [RegularExpression("^[0-9]{11}$", ErrorMessage = "Value needs to be exactly 11 digits.")]
+    public string? Ssn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the organization number of the party to look for.
+    /// </summary>
+    [JsonPropertyName("orgNo")]
+    [RegularExpression("^[0-9]{9}$", ErrorMessage = "Value needs to be exactly 9 digits.")]
+    public string? OrgNo { get; set; }
+
+    /// <summary>
+    /// Error message for when both <see cref="Ssn"/> and <see cref="OrgNo"/> are null.
+    /// </summary>
+    internal static readonly string SsnOrOrgNoRequiredMessage = $"Either {nameof(Ssn)} or {nameof(OrgNo)} is required.";
+
+    /// <summary>
+    /// Error message for when both <see cref="Ssn"/> and <see cref="OrgNo"/> are set.
+    /// </summary>
+    internal static readonly string SsnAndOrgNoExclusiveMessage = $"Only one of {nameof(Ssn)} and {nameof(OrgNo)} is allowed.";
+
+    /// <summary>
+    /// Determines if this instance of the model is valid.
+    /// </summary>
+    /// <param name="validationContext">The current context of the validation check</param>
+    /// <returns>A list of validation results.</returns>
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        /// <summary>
-        /// Gets or sets the social security number of the party to look for.
-        /// </summary>
-        [JsonPropertyName("ssn")]
-        [RegularExpression("^[0-9]{11}$", ErrorMessage = "Value needs to be exactly 11 digits.")]
-        public string Ssn { get; set; }
-
-        /// <summary>
-        /// Gets or sets the organization number of the party to look for.
-        /// </summary>
-        [JsonPropertyName("orgNo")]
-        [RegularExpression("^[0-9]{9}$", ErrorMessage = "Value needs to be exactly 9 digits.")]
-        public string OrgNo { get; set; }
-
-        /// <summary>
-        /// Determines if this instance of the model is valid.
-        /// </summary>
-        /// <param name="validationContext">The current context of the validation check</param>
-        /// <returns>A list of validation results.</returns>
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        if (Ssn is null && OrgNo is null)
         {
-            List<ValidationResult> issues = new List<ValidationResult>();
-
-            if (Ssn != null)
-            {
-                if (OrgNo != null)
-                {
-                    issues.Add(new ValidationResult($"With Ssn already provided the OrgNo field should be null.", new string[] { nameof(OrgNo) }));
-                }
-            }
-            else if (OrgNo == null)
-            {
-                issues.Add(new ValidationResult($"At least one of the object properties must have a value", new string[] { nameof(Ssn), nameof(OrgNo) }));
-            }
-
-            return issues;
+            yield return new ValidationResult(SsnOrOrgNoRequiredMessage, [nameof(Ssn), nameof(OrgNo)]);
+        }
+        else if (Ssn is not null && OrgNo is not null)
+        {
+            yield return new ValidationResult(SsnAndOrgNoExclusiveMessage, [nameof(OrgNo)]);
         }
     }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyName.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyName.cs
@@ -1,28 +1,27 @@
 using System.Text.Json.Serialization;
 
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Represents the party lookup result
+/// </summary>
+public record PartyName
 {
     /// <summary>
-    /// Represents the party lookup result
+    /// Gets or sets the social security number for this result.
     /// </summary>
-    public class PartyName
-    {
-        /// <summary>
-        /// Gets or sets the social security number for this result.
-        /// </summary>
-        [JsonPropertyName("ssn")]
-        public string Ssn { get; set; }
+    [JsonPropertyName("ssn")]
+    public string? Ssn { get; set; }
 
-        /// <summary>
-        /// Gets or sets the organization number for this result.
-        /// </summary>
-        [JsonPropertyName("orgNo")]
-        public string OrgNo { get; set; }
+    /// <summary>
+    /// Gets or sets the organization number for this result.
+    /// </summary>
+    [JsonPropertyName("orgNo")]
+    public string? OrgNo { get; set; }
 
-        /// <summary>
-        /// Gets or sets the party name for this result
-        /// </summary>
-        [JsonPropertyName("name")]
-        public string Name { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the party name for this result
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyNamesLookup.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyNamesLookup.cs
@@ -1,17 +1,15 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Represents a list of lookup criteria when looking for a Party.
+/// </summary>
+public class PartyNamesLookup
 {
     /// <summary>
-    /// Represents a list of lookup criteria when looking for a Party.
+    /// Gets or sets the list of identifiers for the parties to look for.
     /// </summary>
-    public class PartyNamesLookup
-    {
-        /// <summary>
-        /// Gets or sets the list of identifiers for the parties to look for.
-        /// </summary>
-        [JsonPropertyName("parties")]
-        public List<PartyLookup> Parties { get; set; }
-    }
+    [JsonPropertyName("parties")]
+    public IReadOnlyList<PartyLookup>? Parties { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyNamesLookupResult.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/PartyNamesLookupResult.cs
@@ -1,17 +1,15 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Altinn.Platform.Register.Models
+namespace Altinn.Platform.Register.Models;
+
+/// <summary>
+/// Represents a list of party names for each corresponding identifier
+/// </summary>
+public class PartyNamesLookupResult
 {
     /// <summary>
-    /// Represents a list of party names for each corresponding identifier
+    /// Gets or sets the list of identifiers for the parties to look for.
     /// </summary>
-    public class PartyNamesLookupResult
-    {
-        /// <summary>
-        /// Gets or sets the list of identifiers for the parties to look for.
-        /// </summary>
-        [JsonPropertyName("partyNames")]
-        public List<PartyName> PartyNames { get; set; }
-    }
+    [JsonPropertyName("partyNames")]
+    public IReadOnlyList<PartyName>? PartyNames { get; set; }
 }

--- a/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Person.cs
+++ b/src/Altinn.Platform.Models/src/Altinn.Platform.Models/Register/Models/Person.cs
@@ -1,100 +1,97 @@
-using System;
+namespace Altinn.Platform.Register.Models;
 
-namespace Altinn.Platform.Register.Models
+/// <summary>
+/// Class representing a person
+/// </summary>
+public record Person
 {
     /// <summary>
-    /// Class representing a person
+    /// Gets or sets the social security number
     /// </summary>
-    public class Person
-    {
-        /// <summary>
-        /// Gets or sets the social security number
-        /// </summary>
-        public string SSN { get; set; }
+    public string? SSN { get; set; }
 
-        /// <summary>
-        /// Gets a persons name
-        /// </summary>
-        public string Name { get; set; }
+    /// <summary>
+    /// Gets a persons name
+    /// </summary>
+    public string? Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets the first name
-        /// </summary>
-        public string FirstName { get; set; }
+    /// <summary>
+    /// Gets or sets the first name
+    /// </summary>
+    public string? FirstName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the middle name
-        /// </summary>
-        public string MiddleName { get; set; }
+    /// <summary>
+    /// Gets or sets the middle name
+    /// </summary>
+    public string? MiddleName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the last name
-        /// </summary>
-        public string LastName { get; set; }
+    /// <summary>
+    /// Gets or sets the last name
+    /// </summary>
+    public string? LastName { get; set; }
 
-        /// <summary>
-        /// Gets a persons telephone number
-        /// </summary>
-        public string TelephoneNumber { get; set; }
+    /// <summary>
+    /// Gets a persons telephone number
+    /// </summary>
+    public string? TelephoneNumber { get; set; }
 
-        /// <summary>
-        /// Gets a persons mobile number
-        /// </summary>
-        public string MobileNumber { get; set; }
+    /// <summary>
+    /// Gets a persons mobile number
+    /// </summary>
+    public string? MobileNumber { get; set; }
 
-        /// <summary>
-        /// Gets a persons mailing address
-        /// </summary>
-        public string MailingAddress { get; set; }
+    /// <summary>
+    /// Gets a persons mailing address
+    /// </summary>
+    public string? MailingAddress { get; set; }
 
-        /// <summary>
-        /// Gets a persons mailing postal code
-        /// </summary>
-        public string MailingPostalCode { get; set; }
+    /// <summary>
+    /// Gets a persons mailing postal code
+    /// </summary>
+    public string? MailingPostalCode { get; set; }
 
-        /// <summary>
-        /// Gets a persons mailing postal city
-        /// </summary>
-        public string MailingPostalCity { get; set; }
+    /// <summary>
+    /// Gets a persons mailing postal city
+    /// </summary>
+    public string? MailingPostalCity { get; set; }
 
-        /// <summary>
-        /// Gets a persons address municipal number
-        /// </summary>
-        public string AddressMunicipalNumber { get; set; }
+    /// <summary>
+    /// Gets a persons address municipal number
+    /// </summary>
+    public string? AddressMunicipalNumber { get; set; }
 
-        /// <summary>
-        /// Gets a persons address municipal name
-        /// </summary>
-        public string AddressMunicipalName { get; set; }
+    /// <summary>
+    /// Gets a persons address municipal name
+    /// </summary>
+    public string? AddressMunicipalName { get; set; }
 
-        /// <summary>
-        /// Gets a persons address street name
-        /// </summary>
-        public string AddressStreetName { get; set; }
+    /// <summary>
+    /// Gets a persons address street name
+    /// </summary>
+    public string? AddressStreetName { get; set; }
 
-        /// <summary>
-        /// Gets a persons address house number
-        /// </summary>
-        public string AddressHouseNumber { get; set; }
+    /// <summary>
+    /// Gets a persons address house number
+    /// </summary>
+    public string? AddressHouseNumber { get; set; }
 
-        /// <summary>
-        /// Gets a persons address house letter
-        /// </summary>
-        public string AddressHouseLetter { get; set; }
+    /// <summary>
+    /// Gets a persons address house letter
+    /// </summary>
+    public string? AddressHouseLetter { get; set; }
 
-        /// <summary>
-        /// Gets a persons address postal code
-        /// </summary>
-        public string AddressPostalCode { get; set; }
+    /// <summary>
+    /// Gets a persons address postal code
+    /// </summary>
+    public string? AddressPostalCode { get; set; }
 
-        /// <summary>
-        /// Gets a persons address city
-        /// </summary>
-        public string AddressCity { get; set; }
+    /// <summary>
+    /// Gets a persons address city
+    /// </summary>
+    public string? AddressCity { get; set; }
 
-        /// <summary>
-        /// Gets a persons date of death. Null if not dead.
-        /// </summary>
-        public DateTime? DateOfDeath { get; set; }
-    }
+    /// <summary>
+    /// Gets a persons date of death. Null if not dead.
+    /// </summary>
+    public DateTime? DateOfDeath { get; set; }
 }

--- a/src/Altinn.Platform.Models/test/Altinn.Platform.Models.Tests/ModelValidator.cs
+++ b/src/Altinn.Platform.Models/test/Altinn.Platform.Models.Tests/ModelValidator.cs
@@ -13,9 +13,9 @@ namespace Altinn.Platform.Models.Tests
         /// </summary>
         /// <param name="model">The model to validate.</param>
         /// <returns>A list of identified issues.</returns>
-        public static IList<ValidationResult> ValidateModel(object model)
+        public static IReadOnlyList<ValidationResult> ValidateModel(object model)
         {
-            List<ValidationResult> validationResults = new List<ValidationResult>();
+            List<ValidationResult> validationResults = [];
             ValidationContext ctx = new ValidationContext(model, null, null);
             Validator.TryValidateObject(model, ctx, validationResults, true);
             return validationResults;

--- a/src/Altinn.Platform.Models/test/Altinn.Platform.Models.Tests/Register/PartyLookupValidationTests.cs
+++ b/src/Altinn.Platform.Models/test/Altinn.Platform.Models.Tests/Register/PartyLookupValidationTests.cs
@@ -17,10 +17,12 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup();
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.True(issues.All(i => i.MemberNames.Contains("OrgNo") && i.ErrorMessage.Contains("At least one")));
+            var item = issues.Should().ContainSingle().Which;
+            item.MemberNames.Should().Contain([nameof(PartyLookup.OrgNo), nameof(PartyLookup.Ssn)]);
+            item.ErrorMessage.Should().Be(PartyLookup.SsnOrOrgNoRequiredMessage);
         }
 
         [Fact]
@@ -30,10 +32,12 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup { Ssn = "09054300139", OrgNo = "910072218" };
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.True(issues.All(i => i.MemberNames.Contains("OrgNo") && i.ErrorMessage.Contains("With Ssn already")));
+            var item = issues.Should().ContainSingle().Which;
+            item.MemberNames.Should().Contain(nameof(PartyLookup.OrgNo));
+            item.ErrorMessage.Should().Be(PartyLookup.SsnAndOrgNoExclusiveMessage);
         }
 
         [Theory]
@@ -46,10 +50,12 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup { Ssn = ssn };
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.True(issues.All(i => i.MemberNames.Contains("Ssn") && i.ErrorMessage.Contains("exactly 11 digits")));
+            var item = issues.Should().ContainSingle().Which;
+            item.MemberNames.Should().Contain(nameof(PartyLookup.Ssn));
+            item.ErrorMessage.Should().Contain("exactly 11 digits");
         }
 
         [Theory]
@@ -62,10 +68,12 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup { OrgNo = orgNo };
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.True(issues.All(i => i.MemberNames.Contains("OrgNo") && i.ErrorMessage.Contains("exactly 9 digits")));
+            var item = issues.Should().ContainSingle().Which;
+            item.MemberNames.Should().Contain(nameof(PartyLookup.OrgNo));
+            item.ErrorMessage.Should().Contain("exactly 9 digits");
         }
 
         [Theory]
@@ -77,10 +85,10 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup { Ssn = ssn };
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.Empty(issues);
+            issues.Should().BeEmpty();
         }
 
         [Theory]
@@ -92,10 +100,10 @@ namespace Altinn.Platform.Models.Tests.Register
             PartyLookup target = new PartyLookup { OrgNo = orgNo };
 
             // Act
-            IList<ValidationResult> issues = ModelValidator.ValidateModel(target);
+            IReadOnlyList<ValidationResult> issues = ModelValidator.ValidateModel(target);
 
             // Assert
-            Assert.Empty(issues);
+            issues.Should().BeEmpty();
         }
     }
 }

--- a/src/Altinn.Register/src/Altinn.Register.Core/Altinn.Register.Core.csproj
+++ b/src/Altinn.Register/src/Altinn.Register.Core/Altinn.Register.Core.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Platform.Models" />
+    <ProjectReference Include="..\..\..\Altinn.Platform.Models\src\Altinn.Platform.Models\Altinn.Platform.Models.csproj" />
   </ItemGroup>
 
 

--- a/src/Altinn.Register/src/Altinn.Register/Altinn.Register.csproj
+++ b/src/Altinn.Register/src/Altinn.Register/Altinn.Register.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Common.AccessToken" />
     <PackageReference Include="Altinn.Common.PEP" />
-    <PackageReference Include="Altinn.Platform.Models" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
@@ -24,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Altinn.Platform.Models\src\Altinn.Platform.Models\Altinn.Platform.Models.csproj" />
     <ProjectReference Include="..\Altinn.Register.Core\Altinn.Register.Core.csproj" />
   </ItemGroup>
 

--- a/src/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/PartiesControllerTests.cs
+++ b/src/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/PartiesControllerTests.cs
@@ -280,23 +280,26 @@ public class PartiesControllerTests : IClassFixture<WebApplicationFactory<Partie
         Dictionary<string, int> partyIdsByOrgNo = new();
 
         // Arrange
-        PartyNamesLookup input = new PartyNamesLookup
-        {
-            Parties = new List<PartyLookup>()
-        };
-
-        PartyNamesLookupResult expectedResult = new PartyNamesLookupResult
-        {
-            PartyNames = new List<PartyName>()
-        };
+        List<PartyLookup> inputParties = [];
+        List<PartyName> expectedResultPartyNames = [];
 
         foreach (int partyId in partyIds)
         {
             Party party = await TestDataLoader.Load<Party>(partyId.ToString());
-            input.Parties.Add(new PartyLookup { OrgNo = party.OrgNumber });
-            expectedResult.PartyNames.Add(new PartyName { OrgNo = party.OrgNumber, Name = party.Name });
+            inputParties.Add(new PartyLookup { OrgNo = party.OrgNumber });
+            expectedResultPartyNames.Add(new PartyName { OrgNo = party.OrgNumber, Name = party.Name });
             partyIdsByOrgNo.Add(party.OrgNumber, partyId);
         }
+
+        PartyNamesLookup input = new PartyNamesLookup
+        {
+            Parties = inputParties,
+        };
+
+        PartyNamesLookupResult expectedResult = new PartyNamesLookupResult
+        {
+            PartyNames = expectedResultPartyNames,
+        };
 
         HttpRequestMessage sblRequest = null;
         int sblEndpointInvoked = 0;


### PR DESCRIPTION
feat: enable nullable reference types in Altinn.Platform.Models
  BREAKING-CHANGE: This change enables nullable reference types in
  Altinn.Platform.Models. All reference types are set as nullable by
  default and is likely to cause consumers of this library to get
  compiler warnings where they previously did not. Eventually, some of
  these properties will be set as non-nullable. We do not consider this
  a breaking change.

feat: make lists in Altinn.Platform.Models `IReadOnlyList<T>`
  BREAKING-CHANGE: This change makes all lists in Altinn.Platform.Models
  `IReadOnlyList<T>` instead of `List<T>`. This is to enable us to
  change the implementation of these lists in the future without
  breaking consumers of the library. The list properties are still
  writable, so the entire list can be replaced if for some reason that
  is needed.

feat: make most types record
  Most types in Altinn.Platform.Models are now records. This mostly
  provides better `ToString` implementations. This affects how equality
  is determined for these types, but we do not consider this a breaking
  change.

chore: mark `LanguageType` in `ProfileSettingPreference` obsolte
  BREAKING-CHANGE: The `LanguageType` property in
  `ProfileSettingPreference` is marked obsolete. It is a set-only
  property which just proxies to the `Language` property and is only
  present for historical reasons. It will eventually be removed.

chore: make Altinn.Platform.Models target .net 8.0
  BREAKING-CHANGE: Altinn.Platform.Models now targets .net 8.0. This
  means that consumers of this library must also target .net 8.0 or
  later.