### PR TITLE
test: fix pathological worst case of serial tests

### DIFF
--- a/src/Altinn.Register/test/Altinn.Register.TestUtils/PostgreSqlManager.cs
+++ b/src/Altinn.Register/test/Altinn.Register.TestUtils/PostgreSqlManager.cs
@@ -193,16 +193,23 @@ public static class PostgreSqlManager
 
         public static async ValueTask<Container> New()
         {
+            Console.WriteLine("Creating new PostgreSql container...");
+
             var username = Debugger.IsAttached ? "username" : Guid.NewGuid().ToString("N");
             var password = Debugger.IsAttached ? "password" : Guid.NewGuid().ToString("N");
 
-            var container = new PostgreSqlBuilder()
+            var builder = new PostgreSqlBuilder()
                 .WithImage("docker.io/postgres:16.1-alpine")
                 .WithUsername(username)
                 .WithPassword(password)
-                .WithPortBinding(44181, PostgreSqlBuilder.PostgreSqlPort)
-                .WithCleanUp(true)
-                .Build();
+                .WithCleanUp(true);
+
+            if (Debugger.IsAttached)
+            {
+                builder = builder.WithPortBinding(44181, PostgreSqlBuilder.PostgreSqlPort);
+            }
+
+            var container = builder.Build();
 
             try
             {


### PR DESCRIPTION
When tests using DB were run serially, they would not reuse the same database server, and instead each create their own container, leading to substantial overhead. This was fixed by delaying cleanup of the container for a few milliseconds after each test, to allow the next test to reuse the same container.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
