### PR TITLE
chore: improve handling of shared resources in tests

### DIFF
--- a/src/Altinn.Register/test/Altinn.Register.Persistence.Tests/DatabaseTestBase.cs
+++ b/src/Altinn.Register/test/Altinn.Register.Persistence.Tests/DatabaseTestBase.cs
@@ -6,6 +6,7 @@ namespace Altinn.Register.Persistence.Tests;
 
 public abstract class DatabaseTestBase
     : HostTestBase
+    , IClassFixture<PostgreSqlManager>
 {
     private PostgreSqlDatabase? _db;
 

--- a/src/Altinn.Register/test/Altinn.Register.TestUtils/AsyncConcurrencyLimiter.cs
+++ b/src/Altinn.Register/test/Altinn.Register.TestUtils/AsyncConcurrencyLimiter.cs
@@ -3,6 +3,7 @@
 namespace Altinn.Register.TestUtils;
 
 internal class AsyncConcurrencyLimiter
+    : IDisposable
 {
     private readonly SemaphoreSlim _semaphoreSlim;
 

--- a/src/Altinn.Register/test/Altinn.Register.TestUtils/IAsyncRef.cs
+++ b/src/Altinn.Register/test/Altinn.Register.TestUtils/IAsyncRef.cs
@@ -3,11 +3,20 @@ using CommunityToolkit.Diagnostics;
 
 namespace Altinn.Register.TestUtils;
 
-internal interface IAsyncRef
+/// <summary>
+/// An asynchronous reference to a shared resource that can be disposed.
+/// </summary>
+public interface IAsyncRef
     : IAsyncDisposable
 {
+    /// <summary>
+    /// Gets a value indicating whether the reference has been disposed.
+    /// </summary>
     bool IsDisposed { get; }
 
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException"/> if the reference has been disposed.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     void ThrowIfDisposed()
     {

--- a/src/Altinn.Register/test/Altinn.Register.TestUtils/PostgreSqlManager.cs
+++ b/src/Altinn.Register/test/Altinn.Register.TestUtils/PostgreSqlManager.cs
@@ -7,10 +7,15 @@ namespace Altinn.Register.TestUtils;
 /// <summary>
 /// Manager for PostgreSql databases used in tests.
 /// </summary>
-public static class PostgreSqlManager
+public sealed class PostgreSqlManager
+    : SharedResource
 {
     private static readonly AsyncLazyReferenceCounted<Container> _container
         = AsyncLazyReferenceCounted.Create<Container>(allowReuse: true);
+
+    /// <inheritdoc/>
+    protected override async Task<IAsyncRef> GetRef()
+        => await _container.Get();
 
     /// <summary>
     /// Creates a new database.
@@ -231,6 +236,7 @@ public static class PostgreSqlManager
         {
             await _dataSource.DisposeAsync();
             await _container.DisposeAsync();
+            _throttler.Dispose();
         }
     }
 }

--- a/src/Altinn.Register/test/Altinn.Register.TestUtils/SharedResource.cs
+++ b/src/Altinn.Register/test/Altinn.Register.TestUtils/SharedResource.cs
@@ -1,0 +1,53 @@
+﻿using CommunityToolkit.Diagnostics;
+using Xunit;
+
+namespace Altinn.Register.TestUtils;
+
+/// <summary>
+/// An asynchronous reference to a shared resource that can be disposed.
+/// </summary>
+public abstract class SharedResource
+    : IAsyncLifetime
+{
+    private IAsyncRef? _ref;
+
+    /// <summary>
+    /// Gets a reference to the shared resource.
+    /// </summary>
+    /// <returns>A <see cref="IAsyncRef"/>.</returns>
+    protected abstract Task<IAsyncRef> GetRef();
+
+    Task IAsyncLifetime.DisposeAsync()
+    {
+        if (_ref is { } r)
+        {
+            return r.DisposeAsync().AsTask();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    async Task IAsyncLifetime.InitializeAsync()
+    {
+        Guard.IsNull(_ref);
+
+        var r = await GetRef();
+
+        try
+        {
+            r = Interlocked.Exchange(ref _ref, r);
+
+            if (r is not null)
+            {
+                ThrowHelper.ThrowInvalidOperationException("Resource already initialized");
+            }
+        }
+        finally
+        {
+            if (r is not null)
+            {
+                await r.DisposeAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Minor improvement to how shared resources are handled in tests. This increases the determinism of cleanup of async resources in tests which was previously just scheduled to run at a later time, while not re-introducing the issue of database-servers not being reused due to tests running in serial.