### PR TITLE
test: replace Task.Yield with Task.Delay in tests

### DIFF
--- a/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/AsyncEnumerableExtensionsTests.cs
+++ b/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/AsyncEnumerableExtensionsTests.cs
@@ -91,7 +91,7 @@ public class AsyncEnumerableExtensionsTests
         var merged = infiniteSequence.Merge(yielding);
         await foreach (var item in merged)
         {
-            await Task.Yield();
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
 
             if (item == -1)
             {


### PR DESCRIPTION
Give up and use delay instead of yield