### PR TITLE
chore: improve import tracking more

### DIFF
--- a/src/Altinn.Register/src/Altinn.Register.Core/ImportJobs/IImportJobTracker.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/ImportJobs/IImportJobTracker.cs
@@ -25,7 +25,8 @@ public interface IImportJobTracker
     /// idempotent, but also only incrementing with respect to both <see cref="ImportJobQueueStatus.EnqueuedMax"/>, and
     /// <see cref="ImportJobQueueStatus.SourceMax"/>.
     /// </remarks>
-    Task TrackQueueStatus(string id, ImportJobQueueStatus status, CancellationToken cancellationToken = default);
+    /// <returns>Whether or not the job status was updated.</returns>
+    Task<bool> TrackQueueStatus(string id, ImportJobQueueStatus status, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the processing status for the given job.

--- a/src/Altinn.Register/src/Altinn.Register.Core/Utils/ValueTaskExtensions.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/Utils/ValueTaskExtensions.cs
@@ -1,0 +1,43 @@
+﻿#nullable enable
+
+namespace Altinn.Register.Core.Utils;
+
+/// <summary>
+/// Extension methods for <see cref="ValueTask"/> and <see cref="ValueTask{T}"/>.
+/// </summary>
+public static class ValueTaskExtensions
+{
+    /// <summary>
+    /// Gets a <see cref="ValueTask"/> that will complete when this <see cref="ValueTask"/> completes or when the specified timeout expires.
+    /// </summary>
+    /// <param name="task">The <see cref="ValueTask"/> to wait for.</param>
+    /// <param name="timeout">The timeout after which the <see cref="ValueTask"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="timeProvider">The <see cref="TimeProvider"/>.</param>
+    /// <returns>The <see cref="ValueTask"/> representing the asynchronous wait. It may or may not be the same instance as the current instance.</returns>
+    public static ValueTask WaitAsync(this ValueTask task, TimeSpan timeout, TimeProvider timeProvider)
+    {
+        if (task.IsCompleted)
+        {
+            return task;
+        }
+
+        return new(task.AsTask().WaitAsync(timeout, timeProvider));
+    }
+
+    /// <summary>
+    /// Gets a <see cref="ValueTask{T}"/> that will complete when this <see cref="ValueTask{T}"/> completes or when the specified timeout expires.
+    /// </summary>
+    /// <param name="task">The <see cref="ValueTask{T}"/> to wait for.</param>
+    /// <param name="timeout">The timeout after which the <see cref="ValueTask{T}"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <param name="timeProvider">The <see cref="TimeProvider"/>.</param>
+    /// <returns>The <see cref="ValueTask"/> representing the asynchronous wait. It may or may not be the same instance as the current instance.</returns>
+    public static ValueTask<T> WaitAsync<T>(this ValueTask<T> task, TimeSpan timeout, TimeProvider timeProvider)
+    {
+        if (task.IsCompleted)
+        {
+            return task;
+        }
+
+        return new(task.AsTask().WaitAsync(timeout, timeProvider));
+    }
+}


### PR DESCRIPTION
Adds simple caching to the import-tracker, and uses a channel and background worker to reduce concurrency.