### PR TITLE
refactor: unit of work

### DIFF
--- a/src/Altinn.Register/src/Altinn.Register.Contracts/Parties/PartyReference.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Contracts/Parties/PartyReference.cs
@@ -1,10 +1,22 @@
-﻿namespace Altinn.Register.Contracts.Parties;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Altinn.Register.Contracts.Parties;
 
 /// <summary>
 /// Represents a reference to a party.
 /// </summary>
 public sealed record PartyReference
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PartyReference"/> class.
+    /// </summary>
+    /// <param name="partyUuid">The party UUID.</param>
+    [SetsRequiredMembers]
+    public PartyReference(Guid partyUuid)
+    {
+        PartyUuid = partyUuid;
+    }
+
     /// <summary>
     /// Gets the UUID of the party.
     /// </summary>

--- a/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWork.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWork.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Altinn.Register.Core.UnitOfWork;
 
@@ -7,14 +8,10 @@ namespace Altinn.Register.Core.UnitOfWork;
 /// </summary>
 public interface IUnitOfWork
     : IAsyncDisposable
+    , IUnitOfWorkHandle
     , IServiceProvider
     , ISupportRequiredService
 {
-    /// <summary>
-    /// Gets the status of the unit of work.
-    /// </summary>
-    UnitOfWorkStatus Status { get; }
-
     /// <summary>
     /// Commits the unit of work.
     /// </summary>
@@ -30,4 +27,46 @@ public interface IUnitOfWork
     /// if the unit of work has not already been committed or rolled back.
     /// </remarks>
     ValueTask RollbackAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A handle to a unit of work. Can be used to check the status of the unit of work.
+/// </summary>
+public interface IUnitOfWorkHandle
+{
+    /// <summary>
+    /// Gets the status of the unit of work.
+    /// </summary>
+    UnitOfWorkStatus Status { get; }
+
+    /// <summary>
+    /// Throws an exception if the unit of work has been completed.
+    /// </summary>
+    void ThrowIfCompleted()
+    {
+        switch (Status)
+        {
+            case UnitOfWorkStatus.Committed:
+            case UnitOfWorkStatus.RolledBack:
+                ThrowHelper.ThrowInvalidOperationException("The unit of work has been completed.");
+                break;
+
+            case UnitOfWorkStatus.Disposed:
+                ThrowHelper.ThrowObjectDisposedException(nameof(IUnitOfWork), "The unit of work has been disposed.");
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the unit of work has been completed.
+    /// </summary>
+    bool IsCompleted => Status != UnitOfWorkStatus.Active;
+
+    /// <summary>
+    /// Gets a <see cref="CancellationToken"/> that is associated with the unit of work.
+    /// </summary>
+    /// <remarks>
+    /// This cancellation token is linked to the unit of work's lifetime.
+    /// </remarks>
+    CancellationToken Token { get; }
 }

--- a/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWorkManager.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWorkManager.cs
@@ -11,6 +11,17 @@ public interface IUnitOfWorkManager
     /// <summary>
     /// Creates a new unit of work.
     /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <param name="activityName">The name of the activity, used in telemetry.</param>
+    /// <returns>A <see cref="IUnitOfWork"/>.</returns>
+    public ValueTask<IUnitOfWork> CreateAsync(
+        CancellationToken cancellationToken,
+        [CallerMemberName] string activityName = "")
+        => CreateAsync(tags: default, links: default, cancellationToken, activityName);
+
+    /// <summary>
+    /// Creates a new unit of work.
+    /// </summary>
     /// <param name="tags">A set of tags to be added to the activity.</param>
     /// <param name="links">A set of links to be added to the activity.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>

--- a/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWorkParticipantFactory.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/IUnitOfWorkParticipantFactory.cs
@@ -15,8 +15,9 @@ public interface IUnitOfWorkParticipantFactory
     /// <summary>
     /// Factory method for creating a participant in a unit of work.
     /// </summary>
+    /// <param name="handle">A <see cref="IUnitOfWorkHandle"/>.</param>
     /// <param name="serviceProvider">A <see cref="IServiceProvider"/>.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="IUnitOfWorkParticipant"/>.</returns>
-    ValueTask<IUnitOfWorkParticipant> Create(IServiceProvider serviceProvider, CancellationToken cancellationToken = default);
+    ValueTask<IUnitOfWorkParticipant> Create(IUnitOfWorkHandle handle, IServiceProvider serviceProvider, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/UnitOfWorkManager.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/UnitOfWorkManager.cs
@@ -115,11 +115,12 @@ internal class UnitOfWorkManager
         {
             List<Task<(IUnitOfWorkParticipant Participant, int Index)>>? pending = null;
             var builder = ImmutableArray.CreateBuilder<IUnitOfWorkParticipant?>(_participants.Length);
+            var handle = new Handle();
 
             for (var i = 0; i < _participants.Length; i++)
             {
                 var factory = _participants[i];
-                var participant = factory.Create(serviceProvider, cancellationToken);
+                var participant = factory.Create(handle, serviceProvider, cancellationToken);
                 if (participant.IsCompleted)
                 {
                     builder.Add(participant.Result);
@@ -134,27 +135,29 @@ internal class UnitOfWorkManager
 
             if (pending is not null)
             {
-                return WaitForPending(activity, pending, builder, this, serviceProvider, cancellationToken);
+                return WaitForPending(activity, pending, builder, handle, this, serviceProvider, cancellationToken);
             }
 
-            return new(Create(activity, builder, this, serviceProvider));
+            return new(Create(activity, builder, handle, this, serviceProvider));
 
             static IUnitOfWork Create(
                 Activity? activity,
                 ImmutableArray<IUnitOfWorkParticipant?>.Builder participants,
+                Handle handle,
                 Impl impl,
                 IServiceProvider serviceProvider)
             {
                 Debug.Assert(participants.Count == participants.Capacity);
                 Debug.Assert(participants.All(p => p is not null));
 
-                return new UnitOfWork(activity, serviceProvider, participants.MoveToImmutable()!, impl);
+                return new UnitOfWork(handle, activity, serviceProvider, participants.MoveToImmutable()!, impl);
             }
 
             static async ValueTask<IUnitOfWork> WaitForPending(
                 Activity? activity,
                 List<Task<(IUnitOfWorkParticipant Participant, int Index)>> pending,
                 ImmutableArray<IUnitOfWorkParticipant?>.Builder builder,
+                Handle handle,
                 Impl impl,
                 IServiceProvider serviceProvider,
                 CancellationToken cancellationToken)
@@ -167,7 +170,7 @@ internal class UnitOfWorkManager
                     builder[index] = participant;
                 }
 
-                return Create(activity, builder, impl, serviceProvider);
+                return Create(activity, builder, handle, impl, serviceProvider);
             }
 
             static async Task<(IUnitOfWorkParticipant Participant, int Index)> CreatePendingTask(
@@ -188,6 +191,11 @@ internal class UnitOfWorkManager
         /// <returns>A service of type <paramref name="serviceType"/>.</returns>
         private object? GetService(IServiceProvider serviceProvider, UnitOfWork unitOfWork, Type serviceType)
         {
+            if (serviceType == typeof(IUnitOfWorkHandle))
+            {
+                return unitOfWork.Handle;
+            }
+
             if (_services.TryGetValue(serviceType, out var activator))
             {
                 return activator(unitOfWork);
@@ -205,6 +213,11 @@ internal class UnitOfWorkManager
         /// <returns>A service of type <paramref name="serviceType"/>.</returns>
         private object GetRequiredService(IServiceProvider serviceProvider, UnitOfWork unitOfWork, Type serviceType)
         {
+            if (serviceType == typeof(IUnitOfWorkHandle))
+            {
+                return unitOfWork.Handle;
+            }
+
             if (_services.TryGetValue(serviceType, out var activator))
             {
                 return activator(unitOfWork);
@@ -250,6 +263,154 @@ internal class UnitOfWorkManager
             ArrayPool<object?>.Shared.Return(services);
         }
 
+        private sealed class Handle
+            : IUnitOfWorkHandle
+        {
+            private readonly Lock _lock = new();
+            private UnitOfWorkStatus _status = UnitOfWorkStatus.Active;
+            private CancellationTokenSource _cts = new();
+
+#if DEBUG
+            private StackTrace _createdStackTrace = new(skipFrames: 1);
+            private StackTrace? _closedStackTrace = null;
+
+            public void ThrowIfNotDisposed(string displayName)
+            {
+                lock (_lock)
+                {
+                    if (_status != UnitOfWorkStatus.Disposed)
+                    {
+                        Debug.Fail(
+                            $"""
+                            Unit of work was not disposed: {displayName}
+                            {_createdStackTrace}
+                            """);
+                    }
+                }
+            }
+#endif
+
+            public UnitOfWorkStatus Status
+            {
+                get
+                {
+                    lock (_lock)
+                    {
+                        return _status;
+                    }
+                }
+            }
+
+            public CancellationToken Token
+                => _cts.Token;
+
+            /// <summary>
+            /// Marks the unit of work as disposed.
+            /// </summary>
+            /// <returns>
+            /// <see langword="true"/> if the unit of work was disposed by this call; otherwise <see langword="false"/>.
+            /// </returns>
+            public bool Dispose()
+            {
+                lock (_lock)
+                {
+                    if (_status == UnitOfWorkStatus.Disposed)
+                    {
+                        return false;
+                    }
+
+                    _status = UnitOfWorkStatus.Disposed;
+                    _cts.Dispose();
+                    return true;
+                }
+            }
+
+#if DEBUG
+            void IUnitOfWorkHandle.ThrowIfCompleted()
+            {
+                lock (_lock)
+                {
+                    if (_status == UnitOfWorkStatus.Disposed)
+                    {
+                        ThrowHelper.ThrowObjectDisposedException(nameof(IUnitOfWork), "The unit of work has been disposed.");
+                    }
+
+                    if (_status != UnitOfWorkStatus.Active)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException(
+                            $"""
+                            The unit of work has been completed.
+                            
+                            ==================================================
+                            The unit of work was closed at: {_closedStackTrace}.
+
+                            ==================================================
+                            The unit of work was created at: {_createdStackTrace}.
+                            """);
+                    }
+                }
+            }
+#endif
+
+            public void BeginTransitionTo(UnitOfWorkStatus status)
+            {
+#if DEBUG
+                Debug.Assert(status is UnitOfWorkStatus.Committed or UnitOfWorkStatus.RolledBack);
+                var stackTrace = new StackTrace(skipFrames: 2);
+#endif
+
+                lock (_lock)
+                {
+                    if (_status == UnitOfWorkStatus.Disposed)
+                    {
+                        ThrowHelper.ThrowObjectDisposedException(nameof(UnitOfWork));
+                    }
+
+                    if (_status == UnitOfWorkStatus.Committed)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException("Unit of work has already been committed");
+                    }
+
+                    if (_status == UnitOfWorkStatus.RolledBack)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException("Unit of work has already been rolled back");
+                    }
+
+                    _status = status;
+
+#if DEBUG
+                    _closedStackTrace = stackTrace;
+#endif
+                }
+            }
+
+            public Task CompleteTransition()
+            {
+                lock (_lock)
+                {
+                    if (_status is not (UnitOfWorkStatus.Committed or UnitOfWorkStatus.RolledBack))
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+
+                return _cts.CancelAsync();
+            }
+
+            public UnitOfWorkStatus CheckDisposed()
+            {
+                lock (_lock)
+                {
+                    if (_status == UnitOfWorkStatus.Disposed)
+                    {
+                        ThrowHelper.ThrowObjectDisposedException(nameof(UnitOfWork));
+                    }
+
+                    return _status;
+                }
+            }
+        }
+
         private sealed class UnitOfWork
             : IUnitOfWork
         {
@@ -289,20 +450,21 @@ internal class UnitOfWorkManager
                 };
             }
 
+            private readonly Handle _handle;
             private readonly Activity? _activity;
             private readonly IServiceProvider _serviceProvider;
             private readonly ImmutableArray<IUnitOfWorkParticipant> _participants;
             private readonly Impl _impl;
             private object?[] _services;
 
-            private volatile UnitOfWorkStatus _status = UnitOfWorkStatus.Pending;
-
             public UnitOfWork(
+                Handle handle,
                 Activity? activity,
                 IServiceProvider serviceProvider,
                 ImmutableArray<IUnitOfWorkParticipant> participants,
                 Impl impl)
             {
+                _handle = handle;
                 _activity = activity;
                 _serviceProvider = serviceProvider;
                 _participants = participants;
@@ -311,65 +473,69 @@ internal class UnitOfWorkManager
                 _services = _impl.RentServices();
             }
 
-            public UnitOfWorkStatus Status => _status;
+            public Handle Handle
+                => _handle;
+
+            public UnitOfWorkStatus Status
+                => _handle.Status;
+
+            public CancellationToken Token
+                => _handle.Token;
 
 #if DEBUG
             ~UnitOfWork()
             {
-                if (_status != UnitOfWorkStatus.Disposed)
-                {
-                    Debug.Fail($"Unit of work was not disposed: {_activity?.DisplayName ?? "<no display name>"}");
-                }
+                _handle.ThrowIfNotDisposed(_activity?.DisplayName ?? "<no display name>");
             }
 #endif
 
-            public async ValueTask DisposeAsync()
+            public ValueTask DisposeAsync()
             {
 #if DEBUG
                 GC.SuppressFinalize(this);
 #endif
 
-                if (_status == UnitOfWorkStatus.Disposed)
+                if (!_handle.Dispose())
                 {
-                    return;
-                }
-
-                _activity?.Dispose();
-                _status = UnitOfWorkStatus.Disposed;
-
-                foreach (var participant in _participants)
-                {
-                    await participant.DisposeAsync();
-                }
-
-                await _impl.DisposeServices(_services);
-                _services = null!;
-            }
-
-            object? IServiceProvider.GetService(Type serviceType)
-                => _impl.GetService(_serviceProvider, this, serviceType);
-
-            object ISupportRequiredService.GetRequiredService(Type serviceType)
-                => _impl.GetRequiredService(_serviceProvider, this, serviceType);
-
-            public ValueTask CommitAsync(CancellationToken cancellationToken = default)
-            {
-                var status = CheckDisposed();
-
-                if (status == UnitOfWorkStatus.Committed)
-                {
+                    // already disposed
                     return ValueTask.CompletedTask;
                 }
 
-                if (status != UnitOfWorkStatus.Pending)
+                _activity?.Dispose();
+                return DisposeCore();
+
+                async ValueTask DisposeCore()
                 {
-                    ThrowHelper.ThrowInvalidOperationException($"Cannot commit unit of work in state {_status}");
+                    foreach (var participant in _participants)
+                    {
+                        await participant.DisposeAsync();
+                    }
+
+                    await _impl.DisposeServices(_services);
+                    _services = null!;
                 }
+            }
 
-                _status = UnitOfWorkStatus.Committed;
-                return Inner(_activity, _participants, cancellationToken);
+            object? IServiceProvider.GetService(Type serviceType)
+            {
+                _handle.CheckDisposed();
 
-                static async ValueTask Inner(Activity? activity, ImmutableArray<IUnitOfWorkParticipant> participants, CancellationToken cancellationToken)
+                return _impl.GetService(_serviceProvider, this, serviceType);
+            }
+
+            object ISupportRequiredService.GetRequiredService(Type serviceType)
+            {
+                _handle.CheckDisposed();
+
+                return _impl.GetRequiredService(_serviceProvider, this, serviceType);
+            }
+
+            public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+            {
+                _handle.BeginTransitionTo(UnitOfWorkStatus.Committed);
+                return Inner(_handle, _activity, _participants, cancellationToken);
+
+                static async ValueTask Inner(Handle handle, Activity? activity, ImmutableArray<IUnitOfWorkParticipant> participants, CancellationToken cancellationToken)
                 {
                     foreach (var participant in participants)
                     {
@@ -377,27 +543,16 @@ internal class UnitOfWorkManager
                     }
 
                     activity?.SetStatus(ActivityStatusCode.Ok, description: "Committed");
+                    await handle.CompleteTransition();
                 }
             }
 
             public ValueTask RollbackAsync(CancellationToken cancellationToken = default)
             {
-                var status = CheckDisposed();
+                _handle.BeginTransitionTo(UnitOfWorkStatus.RolledBack);
+                return Inner(_handle, _activity, _participants, cancellationToken);
 
-                if (status == UnitOfWorkStatus.RolledBack)
-                {
-                    return ValueTask.CompletedTask;
-                }
-
-                if (status != UnitOfWorkStatus.Pending)
-                {
-                    ThrowHelper.ThrowInvalidOperationException($"Cannot rollback unit of work in state {_status}");
-                }
-
-                _status = UnitOfWorkStatus.RolledBack;
-                return Inner(_activity, _participants, cancellationToken);
-
-                static async ValueTask Inner(Activity? activity, ImmutableArray<IUnitOfWorkParticipant> participants, CancellationToken cancellationToken)
+                static async ValueTask Inner(Handle handle, Activity? activity, ImmutableArray<IUnitOfWorkParticipant> participants, CancellationToken cancellationToken)
                 {
                     foreach (var participant in participants)
                     {
@@ -405,18 +560,8 @@ internal class UnitOfWorkManager
                     }
 
                     activity?.SetStatus(ActivityStatusCode.Ok, description: "Rolled back");
+                    await handle.CompleteTransition();
                 }
-            }
-
-            private UnitOfWorkStatus CheckDisposed()
-            {
-                var status = _status;
-                if (status == UnitOfWorkStatus.Disposed)
-                {
-                    ThrowHelper.ThrowObjectDisposedException(nameof(UnitOfWork));
-                }
-
-                return status;
             }
         }
     }

--- a/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/UnitOfWorkStatus.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/UnitOfWork/UnitOfWorkStatus.cs
@@ -6,9 +6,9 @@
 public enum UnitOfWorkStatus
 {
     /// <summary>
-    /// The unit of work is pending.
+    /// The unit of work is active.
     /// </summary>
-    Pending,
+    Active,
 
     /// <summary>
     /// The unit of work is committed.

--- a/src/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.12-party-updates/00-party-table.sql
+++ b/src/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.12-party-updates/00-party-table.sql
@@ -47,5 +47,5 @@ $BODY$
 LANGUAGE plpgsql;
 
 CREATE TRIGGER update_party_version_id
-BEFORE UPDATE on register.party
+BEFORE UPDATE ON register.party
 FOR EACH ROW EXECUTE PROCEDURE register.update_version_id();

--- a/src/Altinn.Register/src/Altinn.Register/Controllers/V2/PartyController.cs
+++ b/src/Altinn.Register/src/Altinn.Register/Controllers/V2/PartyController.cs
@@ -65,7 +65,7 @@ public class PartyController
             return actionResult;
         }
 
-        await using var uow = await _uowManager.CreateAsync(cancellationToken: cancellationToken);
+        await using var uow = await _uowManager.CreateAsync(cancellationToken);
         var persistence = uow.GetPartyPersistence();
 
         var maxVersionId = await persistence.GetMaxPartyVersionId(cancellationToken);

--- a/src/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportJob.cs
+++ b/src/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportJob.cs
@@ -110,6 +110,9 @@ public sealed partial class A2PartyImportJob
         public Counter<int> PartiesEnqueued { get; }
             = telemetry.CreateCounter<int>("register.party-import.a2.parties.enqueued", "The number of parties enqueued to be imported from A2.");
 
+        public Counter<int> OrganizationCCRRolesEnqueued { get; }
+            = telemetry.CreateCounter<int>("register.party-import.a2.ccr.role-assignments.enqueued", "The number of parties enqueued to be imported ccr role-assignments from A2.");
+
         /// <inheritdoc/>
         public static ImportMeters Create(RegisterTelemetry telemetry)
             => new ImportMeters(telemetry);

--- a/src/Altinn.Register/src/Altinn.Register/PartyImport/PartyImportBatchConsumer.cs
+++ b/src/Altinn.Register/src/Altinn.Register/PartyImport/PartyImportBatchConsumer.cs
@@ -62,7 +62,7 @@ public sealed class PartyImportBatchConsumer
             tracking = ArrayPool<UpsertPartyTracking>.Shared.Rent(BATCH_SIZE);
 
             {
-                await using var uow = await _uow.CreateAsync(cancellationToken: cancellationToken);
+                await using var uow = await _uow.CreateAsync(cancellationToken);
                 var persistence = uow.GetPartyPersistence();
 
                 foreach (var upsert in upserts)
@@ -81,7 +81,7 @@ public sealed class PartyImportBatchConsumer
                     UpdateTracking(ref tracking, upsert.Message.Tracking);
                     evts[index++] = new PartyUpdatedEvent
                     {
-                        Party = new() { PartyUuid = result.Value.PartyUuid.Value },
+                        Party = new(result.Value.PartyUuid.Value),
                     };
                 }
 

--- a/src/Altinn.Register/src/Altinn.Register/PartyImport/PartyImportValidationConsumer.cs
+++ b/src/Altinn.Register/src/Altinn.Register/PartyImport/PartyImportValidationConsumer.cs
@@ -1,9 +1,6 @@
 ﻿#nullable enable
 
 using Altinn.Authorization.ServiceDefaults.MassTransit;
-using Altinn.Register.Core;
-using Altinn.Register.Core.ImportJobs;
-using Altinn.Register.Core.UnitOfWork;
 using MassTransit;
 
 namespace Altinn.Register.PartyImport;

--- a/src/Altinn.Register/src/Altinn.Register/appsettings.Development.json
+++ b/src/Altinn.Register/src/Altinn.Register/appsettings.Development.json
@@ -5,7 +5,8 @@
       "Microsoft": "Warning",
       "System": "Warning",
       "Npgsql.Command": "Warning",
-      "Polly": "Warning"
+      "Polly": "Warning",
+      "Altinn.Authorization.ServiceDefaults.Npgsql.Yuniql": "Trace"
     },
     "ApplicationInsights": {
       "LogLevel": {
@@ -13,6 +14,5 @@
         "Altinn.Register": "None"
       }
     }
-  },
-  "Register:DevProxy:Enable": "true"
+  }
 }

--- a/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/IUnitOfWorkHandleTests.cs
+++ b/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/IUnitOfWorkHandleTests.cs
@@ -19,6 +19,7 @@ public class IUnitOfWorkHandleTests
     public void ThrowIfCompleted_DoesNotThrow_WhenActive()
     {
         using var handle = new FakeUnitOfWorkHandle();
+        
         ((IUnitOfWorkHandle)handle).ThrowIfCompleted();
     }
 

--- a/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/IUnitOfWorkHandleTests.cs
+++ b/src/Altinn.Register/test/Altinn.Register.Tests/UnitTests/IUnitOfWorkHandleTests.cs
@@ -1,0 +1,77 @@
+﻿#nullable enable
+
+using Altinn.Register.Core.UnitOfWork;
+
+namespace Altinn.Register.Tests.UnitTests;
+
+public class IUnitOfWorkHandleTests
+{
+    [Fact]
+    public void ThrowIfCompleted_ThrowsObjectDisposed_WhenDisposed()
+    {
+        using var handle = new FakeUnitOfWorkHandle();
+        ((IDisposable)handle).Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => ((IUnitOfWorkHandle)handle).ThrowIfCompleted());
+    }
+
+    [Fact]
+    public void ThrowIfCompleted_DoesNotThrow_WhenActive()
+    {
+        using var handle = new FakeUnitOfWorkHandle();
+        ((IUnitOfWorkHandle)handle).ThrowIfCompleted();
+    }
+
+    [Fact]
+    public void ThrowIfCompleted_ThrowsInvalidOperationException_WhenCommitted()
+    {
+        using var handle = new FakeUnitOfWorkHandle();
+        handle.Status = UnitOfWorkStatus.Committed;
+
+        Assert.Throws<InvalidOperationException>(() => ((IUnitOfWorkHandle)handle).ThrowIfCompleted());
+    }
+
+    [Fact]
+    public void ThrowIfCompleted_ThrowsInvalidOperationException_WhenRolledBack()
+    {
+        using var handle = new FakeUnitOfWorkHandle();
+        handle.Status = UnitOfWorkStatus.RolledBack;
+
+        Assert.Throws<InvalidOperationException>(() => ((IUnitOfWorkHandle)handle).ThrowIfCompleted());
+    }
+
+    [Theory]
+
+    [InlineData(UnitOfWorkStatus.Active, false)]
+    [InlineData(UnitOfWorkStatus.Committed, true)]
+    [InlineData(UnitOfWorkStatus.RolledBack, true)]
+    [InlineData(UnitOfWorkStatus.Disposed, true)]
+    public void IsCompleted(UnitOfWorkStatus status, bool expected)
+    {
+        using var handle = new FakeUnitOfWorkHandle();
+        handle.Status = status;
+
+        Assert.Equal(expected, ((IUnitOfWorkHandle)handle).IsCompleted);
+    }
+
+    private sealed class FakeUnitOfWorkHandle
+        : IUnitOfWorkHandle
+        , IDisposable
+    {
+        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
+
+        public UnitOfWorkStatus Status { get; set; } = UnitOfWorkStatus.Active;
+
+        UnitOfWorkStatus IUnitOfWorkHandle.Status
+            => Status;
+
+        CancellationToken IUnitOfWorkHandle.Token
+            => throw new NotImplementedException();
+
+        void IDisposable.Dispose()
+        {
+            Status = UnitOfWorkStatus.Disposed;
+            CancellationTokenSource.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Splits `IUnitOfWork` up into `IUnitOfWork` and a `IUnitOfWorkHandle` which helps in debugging logic-errors where the `IUnitOfWork` is used after completion.