### PR TITLE
chore: increase window size used in the Postgres User import service

### DIFF
--- a/src/Altinn.Register/src/Altinn.Register.Persistence/ImportJobs/PostgresUserIdImportJobService.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Persistence/ImportJobs/PostgresUserIdImportJobService.cs
@@ -50,7 +50,7 @@ internal class PostgresUserIdImportJobService
               AND p."party_type" = ANY(@partyTypes)
               AND (@from IS NULL OR p."uuid" > @from)
             ORDER BY p."uuid"
-            LIMIT 1000
+            LIMIT 10000
             """;
 
         Guard.IsNotNullOrEmpty(jobId);


### PR DESCRIPTION
The query used by the postgres user-id import service gets quite slow as the dataset grows. This reduces how often it's needed to re-run by 10x.