### PR TITLE
feat: get party by UUID

### DIFF
--- a/src/Altinn.Register/src/Altinn.Register.Core/Errors/Problems.cs
+++ b/src/Altinn.Register/src/Altinn.Register.Core/Errors/Problems.cs
@@ -25,7 +25,7 @@ public static class Problems
 
     /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
     public static ProblemDescriptor PartyNotFound { get; }
-        = _factory.Create(3, HttpStatusCode.NotFound, "Party not found");
+        = _factory.Create(3, HttpStatusCode.BadRequest, "Party not found");
 
     /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
     public static ProblemDescriptor PartyFetchFailed { get; }

--- a/src/Altinn.Register/src/Altinn.Register/Controllers/AccessManagementController.cs
+++ b/src/Altinn.Register/src/Altinn.Register/Controllers/AccessManagementController.cs
@@ -1,0 +1,34 @@
+﻿using Altinn.Register.Core.Parties;
+using Altinn.Register.Core.Parties.Records;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Register.Controllers;
+
+/// <summary>
+/// Temporary access-management API endpoints.
+/// </summary>
+[ApiController]
+[ApiVersion(1.0)]
+[Authorize(Policy = "InternalOrPlatformAccess")]
+[Route("register/api/v{version:apiVersion}/access-management/parties")]
+public class AccessManagementController(V2.PartyController inner)
+    : ControllerBase
+{
+    /// <summary>
+    /// Gets a single party by its UUID.
+    /// </summary>
+    /// <param name="uuid">The party UUID.</param>
+    /// <param name="fields">The fields to include in the response.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="PartyRecord"/>.</returns>
+    [HttpGet("{uuid:guid}")]
+    [ProducesResponseType<PartyRecord>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest)]
+    public Task<ActionResult<PartyRecord>> GetPartyByUuid(
+        [FromRoute] Guid uuid,
+        [FromQuery(Name = "fields")] PartyFieldIncludes fields = PartyFieldIncludes.Identifiers | PartyFieldIncludes.PartyDisplayName,
+        CancellationToken cancellationToken = default)
+        => inner.GetPartyByUuid(uuid, fields, cancellationToken);
+}

--- a/src/Altinn.Register/test/Altinn.Register.IntegrationTests/IntegrationTestBase.cs
+++ b/src/Altinn.Register/test/Altinn.Register.IntegrationTests/IntegrationTestBase.cs
@@ -23,6 +23,9 @@ public abstract class IntegrationTestBase
     private ITestHarness? _testHarness;
     private ICommandSender? _commandSender;
 
+    protected CancellationToken CancellationToken
+        => TestContext.Current.CancellationToken;
+
     protected JsonSerializerOptions JsonOptions
         => _jsonOptions;
 
@@ -53,7 +56,7 @@ public abstract class IntegrationTestBase
 
     protected async Task<T> Setup<T>(Func<IUnitOfWork, CancellationToken, Task<T>> setup)
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = CancellationToken;
 
         var uowManager = GetRequiredService<IUnitOfWorkManager>();
         await using var uow = await uowManager.CreateAsync(activityName: $"setup {TestContext.Current.Test!.TestDisplayName}", cancellationToken: ct);
@@ -72,7 +75,7 @@ public abstract class IntegrationTestBase
 
     protected async Task<T> Check<T>(Func<IUnitOfWork, CancellationToken, Task<T>> check)
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = CancellationToken;
 
         var uowManager = GetRequiredService<IUnitOfWorkManager>();
         await using var uow = await uowManager.CreateAsync(activityName: $"check {TestContext.Current.Test!.TestDisplayName}", cancellationToken: ct);

--- a/src/Altinn.Register/test/Altinn.Register.IntegrationTests/Party/GetPartyByUUIDTests.cs
+++ b/src/Altinn.Register/test/Altinn.Register.IntegrationTests/Party/GetPartyByUUIDTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Net;
+using Altinn.Authorization.ProblemDetails;
+using Altinn.Register.Core.Errors;
+using Altinn.Register.Core.Parties.Records;
+using Altinn.Register.TestUtils.TestData;
+
+namespace Altinn.Register.IntegrationTests.Party;
+
+public class GetPartyByUUIDTests
+    : IntegrationTestBase
+{
+    [Fact]
+    public async Task NonExistentParty()
+    {
+        var response = await HttpClient.GetAsync($"register/api/v2/internal/parties/{Guid.Empty}", CancellationToken);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+        var content = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+
+        content.ErrorCode.ShouldBe(Problems.PartyNotFound.ErrorCode);
+    }
+
+    [Fact]
+    public async Task DefaultFields()
+    {
+        var party = await Setup((uow, ct) => uow.CreatePerson(cancellationToken: ct));
+
+        var response = await HttpClient.GetAsync($"register/api/v2/internal/parties/{party.PartyUuid.Value}", CancellationToken);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var content = await response.ShouldHaveJsonContent<PartyRecord>();
+        var person = content.ShouldBeOfType<PersonRecord>();
+
+        content.PartyUuid.ShouldBe(party.PartyUuid);
+        content.PartyId.ShouldBe(party.PartyId);
+        content.PersonIdentifier.ShouldBe(party.PersonIdentifier);
+        content.OrganizationIdentifier.ShouldBeNull();
+        content.DisplayName.ShouldBe(party.DisplayName);
+        content.CreatedAt.ShouldBeUnset();
+        content.ModifiedAt.ShouldBeUnset();
+        content.VersionId.ShouldBeUnset();
+        content.User.ShouldBeUnset();
+
+        person.FirstName.ShouldBeUnset();
+        person.MiddleName.ShouldBeUnset();
+        person.LastName.ShouldBeUnset();
+    }
+
+    [Fact]
+    public async Task CustomFields()
+    {
+        var party = await Setup((uow, ct) => uow.CreatePerson(cancellationToken: ct));
+
+        var response = await HttpClient.GetAsync($"register/api/v2/internal/parties/{party.PartyUuid.Value}?fields=party,person", CancellationToken);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var content = await response.ShouldHaveJsonContent<PartyRecord>();
+        var person = content.ShouldBeOfType<PersonRecord>();
+
+        content.PartyUuid.ShouldBe(party.PartyUuid);
+        content.PartyId.ShouldBe(party.PartyId);
+        content.PersonIdentifier.ShouldBe(party.PersonIdentifier);
+        content.OrganizationIdentifier.ShouldBeNull();
+        content.DisplayName.ShouldBe(party.DisplayName);
+        content.CreatedAt.ShouldBe(party.CreatedAt);
+        content.ModifiedAt.ShouldBe(party.ModifiedAt);
+        content.VersionId.ShouldBe(party.VersionId);
+        content.User.ShouldBeUnset();
+
+        person.FirstName.ShouldBe(party.FirstName);
+        person.MiddleName.ShouldBe(party.MiddleName);
+        person.LastName.ShouldBe(party.LastName);
+    }
+}


### PR DESCRIPTION
Adds a new API for getting party by UUID, as well as a access-management endpoint for the same API.