### PR TITLE
Add CODEOWNERS file for team access info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/CODEOWNERS                         @altinn/team-access-info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement CODEOWNERS file in all of our repos, so that repo ownership shows up correctly in the security dashboard.

Example: https://github.com/Altinn/altinn-studio/blob/main/.github/CODEOWNERS

The model used by the security dashboard considers the owner of the CODEOWNERS file as the owner for the entire repo, we should not introduce granular ownership as seen in the example above as this introduces unnecessary amounts of alerts.

## Related Issue(s)
[- #{issue number}](https://github.com/Altinn/altinn-authorization-tmp/issues/1156)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
