### PR TITLE
feat: add external role definitions metadata api

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/ExternalRoles/IExternalRoleDefinitionPersistence.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/ExternalRoles/IExternalRoleDefinitionPersistence.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Register.Contracts;
+using System.Collections.Immutable;
+using Altinn.Register.Contracts;
 using Altinn.Register.Core.Parties.Records;
 
 namespace Altinn.Register.Core.ExternalRoles;
@@ -24,4 +25,11 @@ public interface IExternalRoleDefinitionPersistence
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="ExternalRoleDefinition"/>, if found.</returns>
     public ValueTask<ExternalRoleDefinition?> TryGetRoleDefinitionByRoleCode(string roleCode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves all available external role definitions.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>An array of all available external-role definitions.</returns>
+    public ValueTask<ImmutableArray<ExternalRoleDefinition>> GetAllRoleDefinitions(CancellationToken cancellationToken = default);
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlExternalRoleDefinitionPersistence.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlExternalRoleDefinitionPersistence.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Register.Contracts;
+using System.Collections.Immutable;
+using Altinn.Register.Contracts;
 using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Core.Parties.Records;
 
@@ -20,22 +21,15 @@ internal sealed partial class PostgreSqlExternalRoleDefinitionPersistence
         _cache = cache;
     }
 
-    /// <summary>
-    /// Tries to get the role definition for the specified source and identifier.
-    /// </summary>
-    /// <param name="source">The role definition source.</param>
-    /// <param name="identifier">The role definition identifier.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="ExternalRoleDefinition"/>, if found.</returns>
+    /// <inheritdoc/>
+    public ValueTask<ImmutableArray<ExternalRoleDefinition>> GetAllRoleDefinitions(CancellationToken cancellationToken = default)
+        => _cache.GetAllRoleDefinitions(cancellationToken);
+
+    /// <inheritdoc/>
     public ValueTask<ExternalRoleDefinition?> TryGetRoleDefinition(ExternalRoleSource source, string identifier, CancellationToken cancellationToken = default)
         => _cache.TryGetRoleDefinition(source, identifier, cancellationToken);
 
-    /// <summary>
-    /// Tries to get the role definition for the specified role-code.
-    /// </summary>
-    /// <param name="roleCode">The role definition role-code.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="ExternalRoleDefinition"/>, if found.</returns>
+    /// <inheritdoc/>
     public ValueTask<ExternalRoleDefinition?> TryGetRoleDefinitionByRoleCode(string roleCode, CancellationToken cancellationToken = default)
         => _cache.TryGetRoleDefinitionByRoleCode(roleCode, cancellationToken);
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register/ApiDescriptions/SchemaFilter.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/ApiDescriptions/SchemaFilter.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 
 using Microsoft.OpenApi.Models;
 

--- a/src/apps/Altinn.Register/src/Altinn.Register/ApiDescriptions/TranslatedTextSchemaFilter.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/ApiDescriptions/TranslatedTextSchemaFilter.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using System.Collections.Frozen;
+using System.Diagnostics;
+using Altinn.Register.Contracts;
+using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Altinn.Register.ApiDescriptions;
+
+/// <summary>
+/// Schema filter for fixing translated-text properties.
+/// </summary>
+internal sealed class TranslatedTextSchemaFilter
+    : ISchemaFilter
+{
+    private static readonly FrozenDictionary<Type, FrozenSet<string>> Types
+        = new Dictionary<Type, List<string>>()
+        {
+            { typeof(ExternalRoleMetadata), ["name", "description"] }
+        }
+        .ToFrozenDictionary(
+            static kvp => kvp.Key,
+            static kvp => kvp.Value.ToFrozenSet());
+
+    private readonly IOptionsMonitor<SchemaGeneratorOptions> _settings;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TranslatedTextSchemaFilter"/> class.
+    /// </summary>
+    public TranslatedTextSchemaFilter(IOptionsMonitor<SchemaGeneratorOptions> settings)
+    {
+        _settings = settings;
+    }
+
+    /// <inheritdoc/>
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        Guard.IsNotNull(schema);
+        Guard.IsNotNull(context);
+
+        if (Types.TryGetValue(context.Type, out var props))
+        {
+            FixTranslatedTexts(schema, context, props);
+        }
+
+        return;
+    }
+
+    private void FixTranslatedTexts(OpenApiSchema schema, SchemaFilterContext context, FrozenSet<string> props)
+    {
+        if (schema.Properties is not { Count: > 0 })
+        {
+            return;
+        }
+
+        var translatedTextSchema = GetTranslatedTextSchemaRef(context);
+        foreach (var propName in schema.Properties.Keys)
+        {
+            if (props.Contains(propName))
+            {
+                schema.Properties[propName] = translatedTextSchema;
+            }
+        }
+    }
+
+    private OpenApiSchema GetTranslatedTextSchemaRef(SchemaFilterContext context)
+    {
+        if (context.SchemaRepository.TryLookupByType(typeof(TranslatedText), out var result))
+        {
+            return result;
+        }
+
+        var schema = context.SchemaGenerator.GenerateSchema(typeof(TranslatedText), context.SchemaRepository);
+        schema.Required.Add(LangCode.En.Code);
+        schema.Required.Add(LangCode.Nb.Code);
+        schema.Required.Add(LangCode.Nn.Code);
+        schema.Properties.Add(LangCode.En.Code, new OpenApiSchema
+        {
+            Type = "string",
+        });
+        schema.Properties.Add(LangCode.Nb.Code, new OpenApiSchema
+        {
+            Type = "string",
+        });
+        schema.Properties.Add(LangCode.Nn.Code, new OpenApiSchema
+        {
+            Type = "string",
+        });
+
+        var id = _settings.CurrentValue.SchemaIdSelector(typeof(TranslatedText));
+        context.SchemaRepository.AddDefinition(id, schema);
+        context.SchemaRepository.RegisterType(typeof(TranslatedText), id);
+
+        var found = context.SchemaRepository.TryLookupByType(typeof(TranslatedText), out result);
+        Debug.Assert(found);
+        return result;
+    }
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register/Controllers/V2/MetadataController.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Controllers/V2/MetadataController.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using Altinn.Register.Contracts;
+using Altinn.Register.Core.ExternalRoles;
+using Altinn.Register.Models;
+using Altinn.Register.Utils;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Register.Controllers.V2;
+
+/// <summary>
+/// Provides access to register metadata.
+/// </summary>
+[ApiController]
+[ApiVersion(2.0)]
+[Authorize(Policy = "InternalOrPlatformAccess")]
+[Route("register/api/v{version:apiVersion}/internal/metadata")]
+public class MetadataController
+    : ControllerBase
+{
+    private readonly IExternalRoleDefinitionPersistence _externalRoleDefinitionPersistence;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataController"/> class.
+    /// </summary>
+    public MetadataController(
+        IExternalRoleDefinitionPersistence externalRoleDefinitionPersistence)
+    {
+        _externalRoleDefinitionPersistence = externalRoleDefinitionPersistence;
+    }
+
+    /// <summary>
+    /// Gets metadata for all external roles.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>Metadata for all external roles.</returns>
+    [HttpGet("external-roles")]
+    public async Task<ActionResult<ListObject<ExternalRoleMetadata>>> GetRoleMetadata(
+        CancellationToken cancellationToken = default)
+    {
+        var roles = await _externalRoleDefinitionPersistence.GetAllRoleDefinitions(cancellationToken);
+
+        var result = ListObject.Create(roles.Select(static r => r.ToPartyExternalRoleMetadataContract()));
+        return Ok(result);
+    }
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
@@ -305,6 +305,7 @@ internal static partial class RegisterHost
             c.SupportNonNullableReferenceTypes();
             c.SchemaFilter<PartyComponentOptionSchemaFilter>();
             c.SchemaFilter<PartyFieldIncludesSchemaFilter>();
+            c.SchemaFilter<TranslatedTextSchemaFilter>();
 
             var originalIdSelector = c.SchemaGeneratorOptions.SchemaIdSelector;
             c.SchemaGeneratorOptions.SchemaIdSelector = (Type t) =>

--- a/src/apps/Altinn.Register/src/Altinn.Register/Utils/ContractsMapper.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Utils/ContractsMapper.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Register.Contracts.ExternalRoles;
+using Altinn.Register.Contracts;
+using Altinn.Register.Contracts.ExternalRoles;
 using Altinn.Register.Contracts.Parties;
 using Altinn.Register.Core.Parties.Records;
 
@@ -24,4 +25,20 @@ internal static class ContractsMapper
     /// <returns>A <see cref="ExternalRoleReference"/>.</returns>
     public static ExternalRoleReference ToPartyExternalRoleReferenceContract(this ExternalRoleAssignmentEvent evt)
         => new(evt.RoleSource, evt.RoleIdentifier);
+
+    /// <summary>
+    /// Converts an <see cref="ExternalRoleDefinition"/> instance to an <see cref="ExternalRoleMetadata"/>.
+    /// </summary>
+    /// <param name="role">The external role definition to convert. Cannot be null.</param>
+    /// <returns>An <see cref="ExternalRoleMetadata"/> object containing the metadata from the specified external role
+    /// definition.</returns>
+    public static ExternalRoleMetadata ToPartyExternalRoleMetadataContract(this ExternalRoleDefinition role)
+        => new()
+        {
+            Source = role.Source,
+            Identifier = role.Identifier,
+            Name = role.Name,
+            Description = role.Description,
+            Code = role.Code,
+        };
 }

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Metadata/GetExternalRoleDefinitionsTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Metadata/GetExternalRoleDefinitionsTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using Altinn.Register.Contracts;
+using Altinn.Register.Core.ExternalRoles;
+using Altinn.Register.Models;
+
+namespace Altinn.Register.IntegrationTests.Metadata;
+
+public class GetExternalRoleDefinitionsTests
+    : IntegrationTestBase
+{
+    [Fact]
+    public async Task GetExternalRoles_Returns_ExternalRoles()
+    {
+        var response = await HttpClient.GetAsync("/register/api/v2/internal/metadata/external-roles", TestContext.Current.CancellationToken);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var content = await response.ShouldHaveJsonContent<ListObject<ExternalRoleMetadata>>();
+        var items = content.Items.ToList();
+        items.ShouldNotBeEmpty();
+
+        var allRoles = await GetRequiredService<IExternalRoleDefinitionPersistence>().GetAllRoleDefinitions(TestContext.Current.CancellationToken);
+        items.Count.ShouldBe(allRoles.Length);
+
+        foreach (var role in allRoles)
+        {
+            items.ShouldContain(r => r.Source == role.Source && r.Identifier == role.Identifier);
+            var item = items.Find(r => r.Source == role.Source && r.Identifier == role.Identifier)!;
+
+            item.Code.ShouldBe(role.Code);
+            item.Name.ShouldBe(role.Name);
+            item.Description.ShouldBe(role.Description);
+        }
+    }
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/HealthCheckTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/HealthCheckTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using Altinn.Authorization.ServiceDefaults;
 using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Tests.IntegrationTests.Utils;
+using Altinn.Register.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +23,7 @@ namespace Altinn.Register.Tests.IntegrationTests
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton<IAccessTokenGenerator, TestAccessTokenGenerator>();
+                    services.AddSingleton<IExternalRoleDefinitionPersistence, MockExternalRoleDefinitionPersistence>();
                 });
             });
         }

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/SwaggerEndpointTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/SwaggerEndpointTests.cs
@@ -1,7 +1,9 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Altinn.Authorization.ServiceDefaults;
 using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Tests.IntegrationTests.Utils;
+using Altinn.Register.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,18 +24,21 @@ public class SwaggerEndpointTests
             builder.ConfigureTestServices(services =>
             {
                 services.AddSingleton<IAccessTokenGenerator, TestAccessTokenGenerator>();
+                services.AddSingleton<IExternalRoleDefinitionPersistence, MockExternalRoleDefinitionPersistence>();
             });
         });
     }
 
-    [Fact]
-    public async Task SwaggerDoc_OK()
+    [Theory]
+    [InlineData("v1")]
+    [InlineData("v2")]
+    public async Task SwaggerDoc_OK(string doc)
     {
-        const string RequestUri = "swagger/v1/swagger.json";
+        string requestUri = $"swagger/{doc}/swagger.json";
 
         using var client = _factory.CreateClient();
 
-        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, RequestUri);
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
         using var response = await client.SendAsync(httpRequestMessage);
         response.EnsureSuccessStatusCode();

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/IntegrationTests/Utils/WebApplicationFactorySetup.cs
@@ -7,6 +7,7 @@ using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Register.Clients;
 using Altinn.Register.Clients.Interfaces;
 using Altinn.Register.Configuration;
+using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Core.Parties;
 using Altinn.Register.Tests.Mocks;
 using Altinn.Register.Tests.Mocks.Authentication;
@@ -65,6 +66,7 @@ namespace Altinn.Register.Tests.IntegrationTests.Utils
                     services.AddSingleton<IPublicSigningKeyProvider, PublicSigningKeyProviderMock>();
                     services.AddSingleton<IMemoryCache>(MemoryCache);
                     services.AddSingleton<IAccessTokenGenerator, TestAccessTokenGenerator>();
+                    services.AddSingleton<IExternalRoleDefinitionPersistence, MockExternalRoleDefinitionPersistence>();
 
                     // Using the real/actual implementation of IParties and IPersons, but with a mocked message handler.
                     // Haven't found any other ways of injecting a mocked message handler to simulate SBL Bridge.

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/Mocks/MockExternalRoleDefinitionPersistence.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/Mocks/MockExternalRoleDefinitionPersistence.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using System.Collections.Immutable;
+using Altinn.Register.Contracts;
+using Altinn.Register.Core.ExternalRoles;
+using Altinn.Register.Core.Parties.Records;
+
+namespace Altinn.Register.Tests.Mocks;
+
+public class MockExternalRoleDefinitionPersistence
+    : IExternalRoleDefinitionPersistence
+{
+    public ValueTask<ImmutableArray<ExternalRoleDefinition>> GetAllRoleDefinitions(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<ExternalRoleDefinition?> TryGetRoleDefinition(ExternalRoleSource source, string identifier, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<ExternalRoleDefinition?> TryGetRoleDefinitionByRoleCode(string roleCode, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/TestingControllers/OrganizationsControllerTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/TestingControllers/OrganizationsControllerTests.cs
@@ -7,6 +7,7 @@ using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Register.Clients.Interfaces;
 using Altinn.Register.Contracts.V1;
 using Altinn.Register.Controllers;
+using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Tests.IntegrationTests.Utils;
 using Altinn.Register.Tests.Mocks;
 using Altinn.Register.Tests.Mocks.Authentication;
@@ -38,6 +39,7 @@ namespace Altinn.Register.Tests.TestingControllers
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton<IAccessTokenGenerator, TestAccessTokenGenerator>();
+                    services.AddSingleton<IExternalRoleDefinitionPersistence, MockExternalRoleDefinitionPersistence>();
                 });
             });
         }

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/TestingControllers/Utils/BaseControllerTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/TestingControllers/Utils/BaseControllerTests.cs
@@ -1,10 +1,13 @@
-﻿#nullable enable
+#nullable enable
 
 using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Register.Core.ExternalRoles;
 using Altinn.Register.Tests.IntegrationTests.Utils;
+using Altinn.Register.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Altinn.Register.Tests.TestingControllers.Utils;
 
@@ -29,6 +32,7 @@ public abstract class BaseControllerTests
     protected virtual void ConfigureTestServices(IServiceCollection services)
     {
         services.AddSingleton<IAccessTokenGenerator, TestAccessTokenGenerator>();
+        services.TryAddSingleton<IExternalRoleDefinitionPersistence, MockExternalRoleDefinitionPersistence>();
     }
 
     protected virtual void ConfigureTestConfiguration(IConfigurationBuilder builder)

--- a/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/ExternalRoleMetadata.cs
+++ b/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/ExternalRoleMetadata.cs
@@ -7,6 +7,12 @@ public sealed record ExternalRoleMetadata
     : ExternalRoleRef
 {
     /// <summary>
+    /// Gets the (legacy) role-code of the external role, if it has one.
+    /// </summary>
+    /// <remarks>This is <see langword="null"/> for all newer external-roles.</remarks>
+    public required string? Code { get; init; }
+
+    /// <summary>
     /// Gets the localized names of the external role.
     /// </summary>
     public required TranslatedText Name { get; init; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoint to list all external role metadata.
  * Service API to retrieve all external role definitions.
  * OpenAPI now reuses a shared translated-text schema for role names/descriptions.

* **Bug Fixes / Improvements**
  * Deterministic ordering of in-memory role definitions for consistent results.

* **Changes to Contracts**
  * Added legacy "Code" field to external role metadata and mapping to responses.

* **Tests**
  * Integration test verifying the external-roles metadata endpoint and response content.
  * Swagger test parameterized for multiple doc versions.

* **Chores**
  * Test harness updated with a mock external-role persistence implementation and DI registration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->