### PR TITLE
feat: add self-identified user type

### DIFF
--- a/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/SelfIdentifiedUser.cs
+++ b/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/SelfIdentifiedUser.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Authorization.ModelUtils;
+using Altinn.Authorization.ModelUtils;
 
 namespace Altinn.Register.Contracts;
 
@@ -9,4 +9,9 @@ namespace Altinn.Register.Contracts;
 public sealed record SelfIdentifiedUser()
     : Party(PartyType.SelfIdentifiedUser)
 {
+    /// <summary>
+    /// Gets the type of the self-identified user.
+    /// </summary>
+    [JsonPropertyName("selfIdentifiedUserType")]
+    public FieldValue<NonExhaustiveEnum<SelfIdentifiedUserType>> SelfIdentifiedUserType { get; init; }
 }

--- a/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/SelfIdentifiedUserType.cs
+++ b/src/pkgs/Altinn.Register.Contracts/src/Altinn.Register.Contracts/SelfIdentifiedUserType.cs
@@ -1,0 +1,31 @@
+using Altinn.Authorization.ModelUtils;
+
+namespace Altinn.Register.Contracts;
+
+/// <summary>
+/// Represents a self-identified-user type.
+/// </summary>
+/// <remarks>
+/// This enum is explicitly made such that <c><see langword="default"/>(<see cref="SelfIdentifiedUserType"/>)</c> is not a valid value.
+/// </remarks>
+[StringEnumConverter]
+public enum SelfIdentifiedUserType
+{
+    /// <summary>
+    /// Legacy Altinn 2 Self-Identified User
+    /// </summary>
+    [JsonStringEnumMemberName("legacy")]
+    Legacy = 1,
+
+    /// <summary>
+    /// Educational (FEIDE or UIDP) Self-Identified User
+    /// </summary>
+    [JsonStringEnumMemberName("edu")]
+    Educational,
+
+    /// <summary>
+    /// ID-Porten Email Self-Identified User
+    /// </summary>
+    [JsonStringEnumMemberName("idporten-email")]
+    IdPortenEmail,
+}

--- a/src/pkgs/Altinn.Register.Contracts/test/Altinn.Register.Contracts.Tests/SelfIdentifiedUserTests.cs
+++ b/src/pkgs/Altinn.Register.Contracts/test/Altinn.Register.Contracts.Tests/SelfIdentifiedUserTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Authorization.ModelUtils;
+using Altinn.Authorization.ModelUtils;
 
 namespace Altinn.Register.Contracts.Tests;
 
@@ -20,6 +20,7 @@ public class SelfIdentifiedUserTests
                 DeletedAt = FieldValue.Unset,
                 User = FieldValue.Unset,
                 VersionId = VersionId,
+                SelfIdentifiedUserType = FieldValue.Unset,
             },
             """
             {
@@ -46,6 +47,7 @@ public class SelfIdentifiedUserTests
                 DeletedAt = FieldValue.Null,
                 User = FullUser,
                 VersionId = VersionId,
+                SelfIdentifiedUserType = NonExhaustiveEnum.Create(SelfIdentifiedUserType.Legacy),
             },
             """
             {
@@ -63,7 +65,8 @@ public class SelfIdentifiedUserTests
                 "userId": 50,
                 "username": "username",
                 "userIds": [ 50, 30, 1 ]
-              }
+              },
+              "selfIdentifiedUserType": "legacy"
             }
             """);
     }

--- a/src/pkgs/Altinn.Register.Contracts/test/Altinn.Register.Contracts.Tests/Snapshots/SelfIdentifiedUserTests.MaximalSelfIdentifiedUser.verified.json
+++ b/src/pkgs/Altinn.Register.Contracts/test/Altinn.Register.Contracts.Tests/Snapshots/SelfIdentifiedUserTests.MaximalSelfIdentifiedUser.verified.json
@@ -1,5 +1,6 @@
 ﻿{
   "partyType": "self-identified-user",
+  "selfIdentifiedUserType": "legacy",
   "partyUuid": "00000000-0000-0000-0000-000000000001",
   "versionId": 1,
   "urn": "urn:altinn:party:uuid:00000000-0000-0000-0000-000000000001",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-type classification for self-identified profiles: Legacy, Educational, and ID‑Porten Email.

* **Tests**
  * Updated unit tests and snapshots to include and validate the new user-type field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->