### PR TITLE
chore: limit a2-import concurrency

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportConsumer.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportConsumer.cs
@@ -38,4 +38,22 @@ public sealed partial class A2PartyImportConsumer
     /// <inheritdoc />
     public Task Consume(ConsumeContext<RetryA2PartyImportSagaCommand> context)
         => _manager.HandleMessage<A2PartyImportSaga, RetryA2PartyImportSagaCommand, A2PartyImportSaga.A2PartyImportSagaData>(context);
+
+    /// <summary>
+    /// Consumer definition for <see cref="A2PartyImportConsumer"/>.
+    /// </summary>
+    public sealed class Definition
+        : ConsumerDefinition<A2PartyImportConsumer>
+    {
+        /// <inheritdoc/>
+        protected override void ConfigureConsumer(
+            IReceiveEndpointConfigurator endpointConfigurator,
+            IConsumerConfigurator<A2PartyImportConsumer> consumerConfigurator,
+            IRegistrationContext context)
+        {
+            base.ConfigureConsumer(endpointConfigurator, consumerConfigurator, context);
+
+            endpointConfigurator.ConcurrentMessageLimit = 3;
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adjusted party import message processing concurrency to a fixed limit (reduces simultaneous processing to improve stability and resource use).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->