### PR TITLE
perf: lookup by username uses index

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.PartyQuery.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.PartyQuery.cs
@@ -1061,6 +1061,7 @@ internal partial class PostgreSqlPartyPersistence
                                 FROM register."user" AS "user"
                                 INNER JOIN register.party AS party USING (uuid)
                                 WHERE "user".username = @username
+                                  AND "user".is_active
                                 """);
                         break;
 
@@ -1189,6 +1190,7 @@ internal partial class PostgreSqlPartyPersistence
                             FROM register."user" AS "user"
                             INNER JOIN register.party AS party USING (uuid)
                             WHERE "user".username = ANY (@usernames)
+                              AND "user".is_active
                             """);
                 }
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(user.name; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookup(user.name; type).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids_unfiltered AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookupOne(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers,org.subunits_filterBy=lookupOne(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH top_level_uuids AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = @username
+      AND "user".is_active
 ),
 sub_units AS (
     SELECT

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(user.name; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookup(user.name; type).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids_unfiltered AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookupOne(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=display-name,identifiers_filterBy=lookupOne(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH top_level_uuids AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = @username
+      AND "user".is_active
 ),
 uuids AS (
     SELECT

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(user.name; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookup(user.name; type).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids_unfiltered AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookupOne(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,org.subunits,user_filterBy=lookupOne(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH top_level_uuids AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = @username
+      AND "user".is_active
 ),
 filtered_users AS (
     SELECT "user".*

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(id,uuid,external-urn,pers.id,org.id,user.id,user.name,self-identified.email; type).verified.sql
@@ -37,6 +37,7 @@ uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 uuids_by_self_identified_email AS (
     SELECT si_u."uuid", party.version_id

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(user.name; type).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookup(user.name; type).verified.sql
@@ -6,6 +6,7 @@ WITH uuids_by_username AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = ANY (@usernames)
+      AND "user".is_active
 ),
 top_level_uuids_unfiltered AS (
     SELECT "uuid", version_id FROM uuids_by_username

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookupOne(user.name).verified.sql
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/Snapshots/PartyQueryTests.VerifyQuerySnapshot_includes=party,person,org,si,sysuser,user_filterBy=lookupOne(user.name).verified.sql
@@ -6,6 +6,7 @@ WITH top_level_uuids AS (
     FROM register."user" AS "user"
     INNER JOIN register.party AS party USING (uuid)
     WHERE "user".username = @username
+      AND "user".is_active
 ),
 filtered_users AS (
     SELECT "user".*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined user lookup queries to return only active users. Queries filtering by username, identifier, or ID now exclude inactive users from results across all lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->