### PR TITLE
feat: saga state cleanup job

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/ImportJobs/ISagaStateCleanup.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/ImportJobs/ISagaStateCleanup.cs
@@ -1,0 +1,24 @@
+namespace Altinn.Register.Core.ImportJobs;
+
+/// <summary>
+/// Cleanup for saga state.
+/// </summary>
+public interface ISagaStateCleanup
+{
+    /// <summary>
+    /// Deletes saga states that were completed, faulted, or in progress before the specified dates.
+    /// </summary>
+    /// <param name="completedBefore">The cutoff date for completed saga states. States completed before this date will be deleted. If null,
+    /// completed states are not deleted.</param>
+    /// <param name="faultedBefore">The cutoff date for faulted saga states. States faulted before this date will be deleted. If null, faulted
+    /// states are not deleted.</param>
+    /// <param name="inProgressBefore">The cutoff date for in-progress saga states. States in progress before this date will be deleted. If null,
+    /// in-progress states are not deleted.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>The number of saga states deleted.</returns>
+    public Task<int> DeleteOldStates(
+        DateTimeOffset? completedBefore = null,
+        DateTimeOffset? faultedBefore = null,
+        DateTimeOffset? inProgressBefore = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Microsoft.Extensions.Hosting/RegisterPersistenceExtensions.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Microsoft.Extensions.Hosting/RegisterPersistenceExtensions.cs
@@ -87,8 +87,11 @@ public static class RegisterPersistenceExtensions
         builder.Services.AddUnitOfWorkService<IPartyExternalRolePersistence>(static s => s.GetRequiredService<PostgreSqlPartyPersistence>());
 
         builder.Services.AddUnitOfWorkService<IImportJobStatePersistence, PostgresImportJobStatePersistence>();
-        builder.Services.AddUnitOfWorkService<ISagaStatePersistence, PostgresSagaStatePersistence>();
         builder.Services.AddUnitOfWorkService<IUserIdImportJobService, PostgresUserIdImportJobService>();
+
+        builder.Services.AddUnitOfWorkService<PostgresSagaStatePersistence>();
+        builder.Services.AddUnitOfWorkService<ISagaStatePersistence>(static s => s.GetRequiredService<PostgresSagaStatePersistence>());
+        builder.Services.AddUnitOfWorkService<ISagaStateCleanup>(static s => s.GetRequiredService<PostgresSagaStatePersistence>());
 
         // Not part of unit of work
         builder.Services.AddSingleton<PostgreSqlExternalRoleDefinitionPersistence.Cache>();

--- a/src/apps/Altinn.Register/src/Altinn.Register/Cleanup/SagaStateCleanupJob.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Cleanup/SagaStateCleanupJob.cs
@@ -1,0 +1,71 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+using Altinn.Register.Core.ImportJobs;
+using Altinn.Register.Core.UnitOfWork;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Register.Cleanup;
+
+/// <summary>
+/// Represents a scheduled job responsible for cleaning up saga state data within the system.
+/// </summary>
+public sealed partial class SagaStateCleanupJob
+    : Job
+    , IHasJobName<SagaStateCleanupJob>
+{
+    /// <inheritdoc/>
+    public static string JobName => JobNames.SagaStateCleanup;
+
+    private readonly IUnitOfWorkManager _manager;
+    private readonly IOptionsMonitor<SagaStateCleanupSettings> _settings;
+    private readonly ILogger<SagaStateCleanupJob> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SagaStateCleanupJob"/> class.
+    /// </summary>
+    public SagaStateCleanupJob(
+        IUnitOfWorkManager manager,
+        IOptionsMonitor<SagaStateCleanupSettings> settings,
+        ILogger<SagaStateCleanupJob> logger,
+        TimeProvider timeProvider)
+    {
+        _manager = manager;
+        _settings = settings;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = _settings.CurrentValue;
+
+        await using var uow = await _manager.CreateAsync(cancellationToken, activityName: "cleanup saga states");
+        var cleanup = uow.GetRequiredService<ISagaStateCleanup>();
+
+        var now = _timeProvider.GetUtcNow();
+        var completedCutoff = now - TimeSpan.FromDays(settings.DeleteCompletedSagaStatesAfterDays);
+        var faultedCutoff = now - TimeSpan.FromDays(settings.DeleteFaultedSagaStatesAfterDays);
+        var inProgressCutoff = now - TimeSpan.FromDays(settings.DeleteInProgressSagaStatesAfterDays);
+
+        var deleted = await cleanup.DeleteOldStates(
+            completedBefore: completedCutoff,
+            faultedBefore: faultedCutoff,
+            inProgressBefore: inProgressCutoff,
+            cancellationToken);
+
+        await uow.CommitAsync(cancellationToken);
+        Log.DeletedSagaStates(_logger, deleted, completedCutoff, faultedCutoff, inProgressCutoff);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Information, "Deleted {Deleted} saga states. Completed before {CompletedCutoff}, faulted before {FaultedCutoff}, in-progress before {InProgressCutoff}.")]
+        public static partial void DeletedSagaStates(
+            ILogger<SagaStateCleanupJob> logger,
+            int deleted,
+            DateTimeOffset completedCutoff,
+            DateTimeOffset faultedCutoff,
+            DateTimeOffset inProgressCutoff);
+    }
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register/Cleanup/SagaStateCleanupSettings.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Cleanup/SagaStateCleanupSettings.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Register.Cleanup;
+
+/// <summary>
+/// Provides configuration settings for automatic cleanup of saga state data, including retention periods for completed,
+/// faulted, and in-progress saga states.
+/// </summary>
+public class SagaStateCleanupSettings
+    : IValidatableObject
+{
+    /// <summary>
+    /// Gets or sets the number of days to retain completed saga states before they are deleted.
+    /// </summary>
+    public uint DeleteCompletedSagaStatesAfterDays { get; set; } = 7;
+
+    /// <summary>
+    /// Gets or sets the number of days after which faulted saga states are deleted.
+    /// </summary>
+    public uint DeleteFaultedSagaStatesAfterDays { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets the number of days after which in-progress saga states are deleted.
+    /// </summary>
+    public uint DeleteInProgressSagaStatesAfterDays { get; set; } = 90;
+
+    /// <inheritdoc/>
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (DeleteCompletedSagaStatesAfterDays < 1)
+        {
+            yield return new ValidationResult(
+                $"Value must be greater than 0.",
+                [nameof(DeleteCompletedSagaStatesAfterDays)]);
+        }
+
+        if (DeleteFaultedSagaStatesAfterDays < 1)
+        {
+            yield return new ValidationResult(
+                $"Value must be greater than 0.",
+                [nameof(DeleteFaultedSagaStatesAfterDays)]);
+        }
+
+        if (DeleteInProgressSagaStatesAfterDays < 7)
+        {
+            yield return new ValidationResult(
+                $"Value must be greater than or equal to 7.",
+                [nameof(DeleteInProgressSagaStatesAfterDays)]);
+        }
+    }
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register/JobNames.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/JobNames.cs
@@ -26,4 +26,9 @@ internal static class JobNames
     /// Job name for system user import job.
     /// </summary>
     internal const string SystemUserImport = $"{LeaseNames.SystemUserImport}:systemuser";
+
+    /// <summary>
+    /// Job name for saga state cleanup job.
+    /// </summary>
+    internal const string SagaStateCleanup = "saga-state-cleanup";
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
@@ -9,6 +9,7 @@ using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Common.PEP.Authorization;
 using Altinn.Register.ApiDescriptions;
 using Altinn.Register.Authorization;
+using Altinn.Register.Cleanup;
 using Altinn.Register.Clients;
 using Altinn.Register.Clients.Interfaces;
 using Altinn.Register.Configuration;
@@ -259,6 +260,17 @@ internal static partial class RegisterHost
                 settings.Enabled = JobEnabledBuilder.Default
                     .WithRequireConfigurationValueEnabled("Altinn:register:PartyImport:SystemUsers:Enable")
                     .WithRequireImportJobFinished(A2PartyImportJob.JobName, threshold: 5_000);
+            });
+
+            services.AddOptions<SagaStateCleanupSettings>()
+                .ValidateDataAnnotations()
+                .ValidateOnStart()
+                .BindConfiguration("Altinn:register:Saga:Cleanup");
+
+            services.AddRecurringJob<SagaStateCleanupJob>(settings =>
+            {
+                settings.LeaseName = SagaStateCleanupJob.JobName;
+                settings.Interval = TimeSpan.FromMinutes(15);
             });
         }
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/ImportJobs/PostgresSagaStatePersistenceTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/ImportJobs/PostgresSagaStatePersistenceTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using Altinn.Register.Core.ImportJobs;
 using Altinn.Register.Core.UnitOfWork;
+using Altinn.Register.Persistence.ImportJobs;
 using Altinn.Register.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -142,10 +143,104 @@ public class PostgresSagaStatePersistenceTests
         });
     }
 
-    private async Task Unit(Func<ISagaStatePersistence, Task> action, [CallerMemberName] string name = "")
+    [Fact]
+    public async Task DeleteOldStates_Deletes_Old_States()
+    {
+        var completed = Guid.CreateVersion7();
+        var faulted = Guid.CreateVersion7();
+        var inProgress = Guid.CreateVersion7();
+
+        await Unit(async persistence =>
+        {
+            var completedState = await persistence.GetState<PersonState>(completed);
+            completedState.Data = new PersonState { Age = 30, Name = "Alice" };
+            completedState.Status = SagaStatus.Completed;
+            completedState.Messages.Add(completed);
+            await persistence.SaveState(completedState);
+
+            var faultedState = await persistence.GetState<PersonState>(faulted);
+            faultedState.Data = new PersonState { Age = 40, Name = "Bob" };
+            faultedState.Status = SagaStatus.Faulted;
+            faultedState.Messages.Add(faulted);
+            await persistence.SaveState(faultedState);
+
+            var inProgressState = await persistence.GetState<PersonState>(inProgress);
+            inProgressState.Data = new PersonState { Age = 50, Name = "Charlie" };
+            inProgressState.Status = SagaStatus.InProgress;
+            inProgressState.Messages.Add(inProgress);
+            await persistence.SaveState(inProgressState);
+        });
+
+        // first, we delete old states, even though there are none
+        await DeleteOldStates(expectedDeleted: 0);
+        await CheckNotDeleted([completed, faulted, inProgress]);
+
+        // advance time by 8 days, so the completed state should be old enough to delete
+        TimeProvider.Advance(TimeSpan.FromDays(8));
+        await DeleteOldStates(expectedDeleted: 1);
+        await CheckDeleted(completed);
+        await CheckNotDeleted([faulted, inProgress]);
+
+        // advance time by 23 days (31 days total), so the faulted state should be old enough to delete
+        TimeProvider.Advance(TimeSpan.FromDays(23));
+        await DeleteOldStates(expectedDeleted: 1);
+        await CheckDeleted(faulted);
+        await CheckNotDeleted([inProgress]);
+
+        // advance time by 60 days (91 days total), so the in-progress state should be old enough to delete
+        TimeProvider.Advance(TimeSpan.FromDays(60));
+        await DeleteOldStates(expectedDeleted: 1);
+        await CheckDeleted(inProgress);
+
+        async Task DeleteOldStates(int expectedDeleted)
+        {
+            await Unit(async persistence =>
+            {
+                var now = TimeProvider.GetUtcNow();
+                var completedCutoff = now - TimeSpan.FromDays(7);
+                var faultedCutoff = now - TimeSpan.FromDays(30);
+                var inProgressCutoff = now - TimeSpan.FromDays(90);
+
+                var deleted = await persistence.DeleteOldStates(
+                    completedBefore: completedCutoff,
+                    faultedBefore: faultedCutoff,
+                    inProgressBefore: inProgressCutoff);
+
+                deleted.Should().Be(expectedDeleted);
+            });
+        }
+
+        async Task CheckDeleted(Guid sagaId)
+        {
+            await Unit(async persistence =>
+            {
+                var state = await persistence.GetState<PersonState>(sagaId);
+                state.SagaId.Should().Be(sagaId);
+                state.Status.Should().Be(SagaStatus.InProgress);
+                state.Messages.Should().BeEmpty();
+                state.Data.Should().BeNull();
+            });
+        }
+
+        async Task CheckNotDeleted(IEnumerable<Guid> sagaIds)
+        {
+            await Unit(async persistence =>
+            {
+                foreach (var sagaId in sagaIds)
+                {
+                    var state = await persistence.GetState<PersonState>(sagaId);
+                    state.SagaId.Should().Be(sagaId);
+                    state.Messages.Should().ContainSingle().Which.Should().Be(sagaId);
+                    state.Data.Should().NotBeNull();
+                }
+            });
+        }
+    }
+
+    private async Task Unit(Func<PostgresSagaStatePersistence, Task> action, [CallerMemberName] string name = "")
     {
         await using var uow = await _manager!.CreateAsync(activityName: name);
-        var persistence = uow.GetRequiredService<ISagaStatePersistence>();
+        var persistence = uow.GetRequiredService<PostgresSagaStatePersistence>();
         await action(persistence);
 
         await uow.CommitAsync();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of old saga state data running every 15 minutes.
  * Configurable retention policies with defaults: completed states (7 days), faulted states (30 days), in-progress states (90 days).
  * Retention thresholds customizable through configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->