### PR TITLE
chore: run mt migrations in init

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/RegisterHost.cs
@@ -207,12 +207,13 @@ internal static partial class RegisterHost
 
         var initOnly = config.GetValue<bool>("Altinn:RunInitOnly");
         var isTest = config.GetValue<bool>("Altinn:IsTest");
+        var mtEnabled = config.GetValue<bool>("Altinn:MassTransit:register:Enable");
         if (!initOnly && !isTest)
         {
             const string A2PartyImportJobTag = "a2-import";
             Func<IServiceProvider, CancellationToken, ValueTask> waitForBus = static (s, ct) => new ValueTask(s.GetRequiredService<IBusLifetime>().WaitForBus(ct));
 
-            if (config.GetValue<bool>("Altinn:MassTransit:register:Enable"))
+            if (mtEnabled)
             {
                 builder.AddAltinnMassTransit(
                     configureMassTransit: (cfg) =>
@@ -269,6 +270,10 @@ internal static partial class RegisterHost
                 settings.LeaseName = SagaStateCleanupJob.JobName;
                 settings.Interval = TimeSpan.FromMinutes(15);
             });
+        }
+        else if (initOnly && mtEnabled)
+        {
+            builder.AddAltinnMassTransitMigrations();
         }
 
         services.AddOpenApiExampleProvider();

--- a/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/MassTransitTransportHelper.RabbitMqTransportHelper.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/MassTransitTransportHelper.RabbitMqTransportHelper.cs
@@ -28,18 +28,7 @@ internal abstract partial class MassTransitTransportHelper
             var descriptor = builder.GetAltinnServiceDescriptor();
             var quartzSchema = builder.Configuration.GetValue($"Altinn:MassTransit:{descriptor.Name}:Quartz:Schema", defaultValue: $"{descriptor.Name}_quartz")!;
             var connectionString = builder.Configuration.GetValue<string>($"Altinn:Npgsql:{descriptor.Name}:ConnectionString");
-            var yuniqlSchema = builder.Configuration.GetValue($"Altinn:Npgsql:{descriptor.Name}:Yuniql:MigrationsTable:Schema", defaultValue: "yuniql");
-            var yuniqlTable = builder.Configuration.GetValue($"Altinn:Npgsql:{descriptor.Name}:Yuniql:MigrationsTable:QuartzTable", defaultValue: $"{descriptor.Name}_quartz_migrations");
-            var migrationsFs = new ManifestEmbeddedFileProvider(typeof(MassTransitTransportHelper).Assembly, "Migration");
-
-            builder.AddAltinnPostgresDataSource()
-                .AddYuniqlMigrations(typeof(MassTransitTransportHelper), y =>
-                {
-                    y.WorkspaceFileProvider = migrationsFs;
-                    y.MigrationsTable.Schema = yuniqlSchema;
-                    y.MigrationsTable.Name = yuniqlTable;
-                    y.Tokens.Add("SCHEMA", quartzSchema);
-                });
+            AddMigrations(builder);
 
             builder.Services.AddOptions<RabbitMqTransportOptions>()
                 .Configure(options =>
@@ -73,6 +62,25 @@ internal abstract partial class MassTransitTransportHelper
             {
                 opt.WaitForJobsToComplete = true;
             });
+        }
+
+        public override void AddMigrations(IHostApplicationBuilder builder)
+        {
+            // TODO: make better
+            var descriptor = builder.GetAltinnServiceDescriptor();
+            var quartzSchema = builder.Configuration.GetValue($"Altinn:MassTransit:{descriptor.Name}:Quartz:Schema", defaultValue: $"{descriptor.Name}_quartz")!;
+            var yuniqlSchema = builder.Configuration.GetValue($"Altinn:Npgsql:{descriptor.Name}:Yuniql:MigrationsTable:Schema", defaultValue: "yuniql");
+            var yuniqlTable = builder.Configuration.GetValue($"Altinn:Npgsql:{descriptor.Name}:Yuniql:MigrationsTable:QuartzTable", defaultValue: $"{descriptor.Name}_quartz_migrations");
+            var migrationsFs = new ManifestEmbeddedFileProvider(typeof(MassTransitTransportHelper).Assembly, "Migration");
+
+            builder.AddAltinnPostgresDataSource()
+                .AddYuniqlMigrations(typeof(MassTransitTransportHelper), y =>
+                {
+                    y.WorkspaceFileProvider = migrationsFs;
+                    y.MigrationsTable.Schema = yuniqlSchema;
+                    y.MigrationsTable.Name = yuniqlTable;
+                    y.Tokens.Add("SCHEMA", quartzSchema);
+                });
         }
 
         public override void ConfigureBus(IBusRegistrationConfigurator configurator, Action<IBusRegistrationContext, IBusFactoryConfigurator> configureBus)

--- a/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/MassTransitTransportHelper.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/MassTransitTransportHelper.cs
@@ -81,6 +81,14 @@ internal abstract partial class MassTransitTransportHelper(MassTransitSettings s
     }
 
     /// <summary>
+    /// Configures migrations to be run as part of host-init.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHostApplicationBuilder"/>.</param>
+    public virtual void AddMigrations(IHostApplicationBuilder builder)
+    {
+    }
+
+    /// <summary>
     /// Configures the bus.
     /// </summary>
     /// <param name="configurator">The bus configurator.</param>

--- a/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/Microsoft.Extensions.Hosting/AltinnServiceDefaultsMassTransitExtensions.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.MassTransit/Microsoft.Extensions.Hosting/AltinnServiceDefaultsMassTransitExtensions.cs
@@ -22,6 +22,29 @@ public static class AltinnServiceDefaultsMassTransitExtensions
         => $"Altinn:MassTransit:{connectionName}";
 
     /// <summary>
+    /// Configures migrations to run. This is intended to be used in an init-container.
+    /// </summary>
+    /// <param name="builder">The application builder.</param>
+    public static void AddAltinnMassTransitMigrations(this IHostApplicationBuilder builder)
+    {
+        var serviceDescriptor = builder.GetAltinnServiceDescriptor();
+
+        AddAltinnMassTransitMigrations(builder, DefaultConfigSectionName(serviceDescriptor.Name), serviceDescriptor.Name);
+    }
+
+    private static void AddAltinnMassTransitMigrations(this IHostApplicationBuilder builder, string configurationSectionName, string busName)
+    {
+        Guard.IsNotNull(builder);
+
+        var configuration = builder.Configuration.GetSection(configurationSectionName);
+        MassTransitSettings settings = new();
+        configuration.Bind(settings);
+
+        MassTransitTransportHelper helper = MassTransitTransportHelper.For(settings, busName);
+        helper.AddMigrations(builder);
+    }
+
+    /// <summary>
     /// Adds MassTransit to the host.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder"/>.</param>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and improved migration initialization for background services, extracting migration setup into a reusable extension point.
* **New Features**
  * Added an init-only migration flow allowing migrations to run during host initialization (init-container scenarios).
  * Introduced a configuration flag to toggle MassTransit-related migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->