### PR TITLE
chore: add party-uuid to internal messages

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/PartyImport/A2/A2UserProfileChange.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/PartyImport/A2/A2UserProfileChange.cs
@@ -14,7 +14,7 @@ public sealed record A2UserProfileChange
     /// <summary>
     /// Gets the user uuid that changed.
     /// </summary>
-    public required Guid? UserUuid { get; init; }
+    public required Guid UserUuid { get; init; }
 
     /// <summary>
     /// Gets the party uuid of the owner of the user profile.

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.EnrichA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.EnrichA2PartyImportSagaCommand.cs
@@ -15,6 +15,7 @@ public partial class A2PartyImportSaga
                   new CompleteA2PartyImportSagaCommand
                   {
                       CorrelationId = SagaId,
+                      PartyUuid = State.PartyUuid,
                   },
                   cancellationToken);
             return;

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportA2ProfileCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportA2ProfileCommand.cs
@@ -16,7 +16,7 @@ public partial class A2PartyImportSaga
     public static ValueTask<A2PartyImportSagaData> CreateInitialState(IServiceProvider services, ImportA2UserProfileCommand command)
         => ValueTask.FromResult(new A2PartyImportSagaData
         {
-            PartyUuid = command.OwnerPartyUuid,
+            PartyUuid = command.PartyUuid,
             UserId = command.UserId,
             Tracking = command.Tracking,
         });
@@ -24,7 +24,7 @@ public partial class A2PartyImportSaga
     /// <inheritdoc/>
     public async Task Handle(ImportA2UserProfileCommand message, CancellationToken cancellationToken)
     {
-        Debug.Assert(message.OwnerPartyUuid == State.PartyUuid);
+        Debug.Assert(message.PartyUuid == State.PartyUuid);
 
         var now = _timeProvider.GetUtcNow();
 

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.cs
@@ -88,6 +88,7 @@ public sealed partial class A2PartyImportSaga
                   new EnrichA2PartyImportSagaCommand
                   {
                       CorrelationId = SagaId,
+                      PartyUuid = State.PartyUuid,
                   },
                   cancellationToken);
 
@@ -98,6 +99,7 @@ public sealed partial class A2PartyImportSaga
             new CompleteA2PartyImportSagaCommand
             {
                 CorrelationId = SagaId,
+                PartyUuid = State.PartyUuid,
             },
             cancellationToken);
     }

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2ProfileImportJob.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2ProfileImportJob.cs
@@ -80,6 +80,7 @@ public sealed partial class A2ProfileImportJob
             var cmds = page.Select(static update => new ImportA2UserProfileCommand
             {
                 UserId = update.UserId,
+                PartyUuid = update.UserUuid,
                 OwnerPartyUuid = update.OwnerPartyUuid,
                 IsDeleted = update.IsDeleted,
                 Tracking = new(JobName, update.ChangeId),

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/CompleteA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/CompleteA2PartyImportSagaCommand.cs
@@ -10,4 +10,8 @@ namespace Altinn.Register.PartyImport.A2;
 public sealed record CompleteA2PartyImportSagaCommand
     : CommandBase
 {
+    /// <summary>
+    /// Gets the party UUID.
+    /// </summary>
+    public required Guid PartyUuid { get; init; }
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/EnrichA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/EnrichA2PartyImportSagaCommand.cs
@@ -10,4 +10,8 @@ namespace Altinn.Register.PartyImport.A2;
 public sealed record EnrichA2PartyImportSagaCommand
     : CommandBase
 {
+    /// <summary>
+    /// Gets the party UUID.
+    /// </summary>
+    public required Guid PartyUuid { get; init; }
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/ImportA2UserProfileCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/ImportA2UserProfileCommand.cs
@@ -16,6 +16,11 @@ public sealed record ImportA2UserProfileCommand
     public required ulong UserId { get; init; }
 
     /// <summary>
+    /// Gets the party UUID.
+    /// </summary>
+    public required Guid PartyUuid { get; init; }
+
+    /// <summary>
     /// Gets the owner party UUID.
     /// </summary>
     public required Guid OwnerPartyUuid { get; init; }

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/RetryA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/RetryA2PartyImportSagaCommand.cs
@@ -10,4 +10,8 @@ namespace Altinn.Register.PartyImport.A2;
 public sealed record RetryA2PartyImportSagaCommand
     : CommandBase
 {
+    /// <summary>
+    /// Gets the party UUID.
+    /// </summary>
+    public required Guid PartyUuid { get; init; }
 }

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/PartyImport/PartyImportFlowTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/PartyImport/PartyImportFlowTests.cs
@@ -104,6 +104,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = oldId,
+            PartyUuid = person.PartyUuid.Value,
             OwnerPartyUuid = person.PartyUuid.Value,
             IsDeleted = true,
             Tracking = new("test", 10),
@@ -250,6 +251,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = userId,
+            PartyUuid = person.PartyUuid.Value,
             OwnerPartyUuid = person.PartyUuid.Value,
             IsDeleted = false,
             Tracking = new("test", 10),
@@ -471,6 +473,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = userId,
+            PartyUuid = person.PartyUuid.Value,
             OwnerPartyUuid = person.PartyUuid.Value,
             IsDeleted = false,
             Tracking = new("test", 10),
@@ -594,6 +597,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = userId,
+            PartyUuid = person.PartyUuid.Value,
             OwnerPartyUuid = person.PartyUuid.Value,
             IsDeleted = true,
             Tracking = new("test", 10),
@@ -707,6 +711,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = userId,
+            PartyUuid = siUser.PartyUuid.Value,
             OwnerPartyUuid = siUser.PartyUuid.Value,
             IsDeleted = false,
             Tracking = new("test", 10),
@@ -821,6 +826,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = userId,
+            PartyUuid = siUser.PartyUuid.Value,
             OwnerPartyUuid = siUser.PartyUuid.Value,
             IsDeleted = true,
             Tracking = new("test", 10),
@@ -1151,6 +1157,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = id,
+            PartyUuid = uuid,
             OwnerPartyUuid = org.PartyUuid.Value,
             IsDeleted = false,
             Tracking = new("test", 10),
@@ -1256,6 +1263,7 @@ public class PartyImportFlowTests
         var cmd = new ImportA2UserProfileCommand
         {
             UserId = id,
+            PartyUuid = uuid,
             OwnerPartyUuid = org.PartyUuid.Value,
             IsDeleted = true,
             Tracking = new("test", 10),
@@ -1372,6 +1380,7 @@ public class PartyImportFlowTests
         await UpsertParty(new ImportA2UserProfileCommand
         {
             UserId = siUserId,
+            PartyUuid = siUuid,
             OwnerPartyUuid = siUuid,
             IsDeleted = false,
             Tracking = new("test", 10),
@@ -1454,6 +1463,7 @@ public class PartyImportFlowTests
         await UpsertParty(new ImportA2UserProfileCommand
         {
             UserId = siUserId,
+            PartyUuid = siUuid,
             OwnerPartyUuid = siUuid,
             IsDeleted = true,
             Tracking = new("test", 11),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved party import workflow reliability by ensuring party identifiers are consistently tracked and propagated through all import commands and saga processes.
  * Enhanced data consistency in A2 user profile imports by strengthening party UUID requirements and validation.

* **Tests**
  * Updated integration tests to validate party UUID handling in user profile import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->