### PR TITLE
fix: retry command optional partyUuid

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/RetryA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/RetryA2PartyImportSagaCommand.cs
@@ -13,5 +13,5 @@ public sealed record RetryA2PartyImportSagaCommand
     /// <summary>
     /// Gets the party UUID.
     /// </summary>
-    public required Guid PartyUuid { get; init; }
+    public Guid? PartyUuid { get; init; }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified the party import retry command to accept optional party UUID values, allowing greater flexibility in command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->