### PR TITLE
chore: allow disable record

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/Controllers/CcrController.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Controllers/CcrController.cs
@@ -58,7 +58,9 @@ public partial class CcrController
     [ApiExplorerSettings(IgnoreApi = true)]
     [ConfigurationCondition("Altinn:register:Ccr:Update:Enabled")]
     [RequestSizeLimit(50_000_000 /* 50 MB */)]
-    public async Task Update(CancellationToken cancellationToken = default)
+    public async Task Update(
+        [FromQuery(Name = "record")] bool record = true,
+        CancellationToken cancellationToken = default)
     {
         using RecordOperationState state = new(_timeProvider.GetUtcNow(), Request.GetDisplayUrl());
 
@@ -79,7 +81,7 @@ public partial class CcrController
         await state.WriteResponse(Response, cancellationToken);
         await Response.CompleteAsync();
 
-        if (_configuration.GetValue("Altinn:register:Ccr:Update:Record", defaultValue: false))
+        if (record && _configuration.GetValue("Altinn:register:Ccr:Update:Record", defaultValue: false))
         {
             Log.EnqueueRecordingCcrUpdate(_logger);
             EnqueueRecord(state);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control mechanism for Central Commercial Register updates. Users can now configure whether updates should be recorded through a new optional parameter. Recording is enabled by default, ensuring backward compatibility with existing configurations. This enhancement provides greater operational flexibility in managing how system updates are tracked, recorded, and maintained within the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->