### PR TITLE
fix: map username to party.Name for SI users

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyById.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyById.cs
@@ -50,7 +50,7 @@ internal sealed class GetV1PartyByIdFromDBRequestHandler(IUnitOfWorkManager mana
         var persistence = uow.GetPartyPersistence();
 
         var party = await persistence
-            .GetPartyById(request.PartyId, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization, cancellationToken)
+            .GetPartyById(request.PartyId, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (party is null)

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyByUuid.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyByUuid.cs
@@ -50,7 +50,7 @@ internal sealed class GetV1PartyByUuidFromDBRequestHandler(IUnitOfWorkManager ma
         var persistence = uow.GetPartyPersistence();
 
         var party = await persistence
-            .GetPartyById(request.PartyUuid, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization, cancellationToken)
+            .GetPartyById(request.PartyUuid, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (party is null)

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyListById.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyListById.cs
@@ -52,7 +52,7 @@ internal sealed class GetV1PartyListByIdFromDBRequestHandler(IUnitOfWorkManager 
             yield break;
         }
 
-        var include = PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization;
+        var include = PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User;
         if (request.FetchSubUnits)
         {
             include |= PartyFieldIncludes.SubUnits;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyListByUuid.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyListByUuid.cs
@@ -57,7 +57,7 @@ internal sealed class GetV1PartyListByUuidFromDBRequestHandler(IUnitOfWorkManage
             yield break;
         }
 
-        var include = PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization;
+        var include = PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User;
         if (request.FetchSubUnits)
         {
             include |= PartyFieldIncludes.SubUnits;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/Mapping/V1PartyMapper.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/Mapping/V1PartyMapper.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Altinn.Authorization.ModelUtils;
 using Altinn.Register.Core.Parties.Records;
 using V1Models = Altinn.Register.Contracts.V1;
 
@@ -45,8 +46,9 @@ internal static class V1PartyMapper
                 ret.Person = mappedPerson;
                 break;
 
-            case SelfIdentifiedUserRecord:
+            case SelfIdentifiedUserRecord siUser:
                 ret.PartyTypeName = V1Models.PartyType.SelfIdentified;
+                ret.Name = siUser.User.SelectFieldValue(static u => u.Username).OrDefault(siUser.DisplayName.Value);
                 break;
 
             default:

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/PartiesControllerTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/PartiesControllerTests.cs
@@ -113,7 +113,7 @@ public class PartiesControllerTests
             (Contracts.V1.Party p) => p.PartyId.ShouldBe((int)siUser.PartyId.Value),
             (Contracts.V1.Party p) => p.PartyUuid.ShouldBe(siUser.PartyUuid.Value),
             (Contracts.V1.Party p) => p.PartyTypeName.ShouldBe(Contracts.V1.PartyType.SelfIdentified),
-            (Contracts.V1.Party p) => p.Name.ShouldBe(siUser.DisplayName.Value),
+            (Contracts.V1.Party p) => p.Name.ShouldBe(siUser.User.Value!.Username.Value!),
             (Contracts.V1.Party p) => p.Person.ShouldBeNull(),
             (Contracts.V1.Party p) => p.Organization.ShouldBeNull(),
         ]);
@@ -349,7 +349,7 @@ public class PartiesControllerTests
             (Contracts.V1.Party p) => p.PartyId.ShouldBe((int)siUser.PartyId.Value),
             (Contracts.V1.Party p) => p.PartyUuid.ShouldBe(siUser.PartyUuid.Value),
             (Contracts.V1.Party p) => p.PartyTypeName.ShouldBe(Contracts.V1.PartyType.SelfIdentified),
-            (Contracts.V1.Party p) => p.Name.ShouldBe(siUser.DisplayName.Value),
+            (Contracts.V1.Party p) => p.Name.ShouldBe(siUser.User.Value!.Username.Value!),
             (Contracts.V1.Party p) => p.Person.ShouldBeNull(),
             (Contracts.V1.Party p) => p.Organization.ShouldBeNull(),
         ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated party name resolution for self-identified users to use correct field mapping with appropriate fallback values, ensuring accurate data display in the registration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->