### PR TITLE
fix: handle NPR having changed person-identifier

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/Enrichers/NprEnricher.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/Enrichers/NprEnricher.cs
@@ -57,8 +57,10 @@ internal sealed class NprEnricher
 
         if (nprPerson.PersonIdentifier != context.Party.PersonIdentifier.Value)
         {
-            // This should never happen, but if it does, it indicates a serious problem with the NPR client or the data in NPR, so we want to fail rather than risk importing incorrect data.
-            throw new InvalidOperationException($"NPR returned a different person-identifier than requested.");
+            // This happens if a person has ever changed their person-identifier and we used the old one to look them up.
+            // NPR will return the correct person with the current person-identifier. But since we have a separate party
+            // for each person-identifier, we need to save the data we get on the old party here.
+            nprPerson = nprPerson with { PersonIdentifier = context.Party.PersonIdentifier.Value };
         }
 
         context.Party = ((PersonRecord)context.Party) with


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where party information retrieval from the national registry would fail when the registry returned a different personal identifier than the one initially requested. The system now properly handles this identifier mismatch scenario, allowing party data updates and related operations to proceed correctly without interruption, improving overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->