### PR TITLE
fix: make more NPR data optional

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -55,7 +55,7 @@ set windows-shell := ["pwsh.exe", "-NoLogo", "-CommandWithArgs"]
 @fetch-tenor-id ID:
   #!{{shebang}}
   $null = New-Item -Type Directory -Force "src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/{{ID}}"
-  $response = Invoke-WebRequest -Uri "http://localhost:5020/register/api/v0/debug/npr/person/{{ID}}"
+  $response = Invoke-WebRequest -Uri "http://localhost:5020/register/api/v0/debug/npr/raw/{{ID}}"
   $response.Content | prettier --parser json | Out-File -FilePath "src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/{{ID}}/npr.json"
 
 @accept-npr-valid-results:

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Npr/NprPerson.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Npr/NprPerson.cs
@@ -52,7 +52,7 @@ public sealed record NprPerson
     /// <summary>
     /// Gets the date of birth of the person.
     /// </summary>
-    public required DateOnly DateOfBirth { get; init; }
+    public required DateOnly? DateOfBirth { get; init; }
 
     /// <summary>
     /// Gets the (optional) date of death of the person.

--- a/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Npr/Person/PersonDocumentValidator.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Npr/Person/PersonDocumentValidator.cs
@@ -27,10 +27,10 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
     , IValidator<GuardianshipServiceArea, Optional<string>>
     , IValidator<PersonStatusElement, PersonStatus>
     , IValidator<IdentificationNumberElement, PersonIdentifier>
-    , IValidator<BirthElement, DateOnly>
+    , IValidator<BirthElement, Optional<DateOnly>>
     , IValidator<AddressProtectionElement, Optional<AddressConfidentialityLevel>>
     , IValidator<ResidentialAddressElement, Optional<StreetAddressRecord>>
-    , IValidator<NameElement, PersonDocumentValidator.PersonName>
+    , IValidator<NameElement, Optional<PersonDocumentValidator.PersonName>>
     , IValidator<DeathElement?, PersonDocumentValidator.PersonDeath>
     , IValidator<MailingAddressElement, Optional<PersonDocumentValidator.MailingAddressRecordExt>>
     , IValidator<CurrentStayAddressElement, Optional<PersonDocumentValidator.MailingAddressRecordExt>>
@@ -67,14 +67,14 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         context.TryValidateChild(
             path: "/navn",
             input.Name,
-            ActiveElementValidator.Required<NameElement, PersonName, PersonDocumentValidator>(this),
-            out PersonName personName);
+            ActiveElementValidator.Optional<NameElement, PersonName, PersonDocumentValidator>(this),
+            out Optional<PersonName> personNameOpt);
 
         context.TryValidateChild(
             path: "/foedsel",
             input.Birth,
-            ActiveElementValidator.Required<BirthElement, DateOnly, PersonDocumentValidator>(this),
-            out DateOnly dateOfBirth);
+            ActiveElementValidator.Optional<BirthElement, DateOnly, PersonDocumentValidator>(this),
+            out Optional<DateOnly> dateOfBirth);
 
         context.TryValidateChild(
             path: "/doedsfall",
@@ -87,6 +87,21 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
             input.AddressProtection,
             ActiveElementValidator.Optional<AddressProtectionElement, AddressConfidentialityLevel, PersonDocumentValidator>(this),
             out Optional<AddressConfidentialityLevel> addressProtectionLevel);
+
+        PersonName personName;
+        if (personNameOpt.HasValue)
+        {
+            personName = personNameOpt.Value;
+        }
+        else
+        {
+            personName = new PersonName(
+                FirstName: "Mangler",
+                MiddleName: null,
+                LastName: "Navn",
+                DisplayName: "Mangler Navn",
+                ShortName: "Mangler Navn");
+        }
 
         MailingAddressRecordExt? mailingAddress = null;
         StreetAddressRecord? address = null;
@@ -162,7 +177,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
             ShortName = personName.ShortName,
 
             // Birth and death
-            DateOfBirth = dateOfBirth,
+            DateOfBirth = dateOfBirth.HasValue ? dateOfBirth.Value : null,
             DateOfDeath = death.DateOfDeath,
 
             // Addresses
@@ -348,7 +363,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
     public bool TryValidate(
         ref ValidationContext context,
         BirthElement input,
-        [NotNullWhen(true)] out DateOnly validated)
+        [NotNullWhen(true)] out Optional<DateOnly> validated)
     {
         const string PATH = "/foedselsdato";
 
@@ -359,20 +374,22 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
             return false;
         }
 
-        if (!DateOnly.TryParseExact(input.DateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out validated))
+        if (!DateOnly.TryParseExact(input.DateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var validatedDate))
         {
             context.AddChildProblem(ValidationErrors.InvalidDate, path: PATH, detail: $"The value '{input.DateOfBirth}' is not a valid date.");
+            validated = default;
             return false;
         }
 
+        validated = validatedDate;
         return true;
     }
 
     /// <inheritdoc/>
-    bool IValidator<NameElement, PersonName>.TryValidate(
+    bool IValidator<NameElement, Optional<PersonName>>.TryValidate(
         ref ValidationContext context,
         NameElement input,
-        out PersonName validated)
+        out Optional<PersonName> validated)
     {
         var firstName = input.FirstName?.Trim();
         var middleName = input.MiddleName?.Trim();
@@ -422,7 +439,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
 
         Debug.Assert(firstName is not null);
         Debug.Assert(lastName is not null);
-        validated = new(
+        validated = new PersonName(
             FirstName: firstName,
             MiddleName: middleName,
             LastName: lastName,
@@ -807,13 +824,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         FreeFormMailingAddress input,
         [NotNullWhen(true)] out MailingAddressRecordExt? validated)
     {
-        PostalInfo postalInfo;
-        if (input.PostalArea is null)
-        {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postalInfo = default;
-        }
-        else
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
             context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
@@ -830,7 +842,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         }
 
         var address = string.Join(' ', input.AddressLines);
-        if (input.AddressLines.Length > 0 && !input.AddressLines[^1].StartsWith(postalInfo.Code, StringComparison.Ordinal))
+        if (input.AddressLines.Length > 0 && (postalInfo.Code is null || !input.AddressLines[^1].StartsWith(postalInfo.Code, StringComparison.Ordinal)))
         {
             address = $"{address} {postalInfo.Code} {postalInfo.Name}".Trim();
         }
@@ -852,13 +864,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         StreetAddress input,
         [NotNullWhen(true)] out MailingAddressRecordExt? validated)
     {
-        PostalInfo postalInfo;
-        if (input.PostalArea is null)
-        {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postalInfo = default;
-        }
-        else
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
             context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
@@ -885,13 +892,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         StreetAddress input,
         [NotNullWhen(true)] out StreetAddressRecord? validated)
     {
-        PostalInfo postalInfo;
-        if (input.PostalArea is null)
-        {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postalInfo = default;
-        }
-        else
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
             context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
@@ -923,13 +925,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         PostBoxAddress input,
         [NotNullWhen(true)] out MailingAddressRecordExt? validated)
     {
-        PostalInfo postalInfo;
-        if (input.PostalArea is null)
-        {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postalInfo = default;
-        }
-        else
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
             context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
@@ -1047,15 +1044,10 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         MatrikkelAddress input,
         [NotNullWhen(true)] out MailingAddressRecordExt? validated)
     {
-        PostalInfo postal;
-        if (input.PostalArea is null)
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postal = default;
-        }
-        else
-        {
-            context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postal);
+            context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
 
         if (context.HasErrors)
@@ -1067,9 +1059,9 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         List<string> addressLines = new List<string>();
         bool isCoAddress = false;
 
-        if (postal.Code == null)
+        if (postalInfo.Code == null)
         {
-            postal = postal with { Code = "0000" };
+            postalInfo = postalInfo with { Code = "0000" };
         }
 
         if (!string.IsNullOrWhiteSpace(input.CareOfAddressName))
@@ -1122,16 +1114,16 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
             addressLines.Add(cadastralNumber.ToString());
         }
 
-        if (postal.Code != "0000" && !string.IsNullOrEmpty(postal.Name))
+        if (postalInfo.Code != "0000" && !string.IsNullOrEmpty(postalInfo.Name))
         {
-            addressLines.Add(postal.Code.Trim().PadLeft(4, '0') + " " + postal.Name.Trim());
+            addressLines.Add(postalInfo.Code.Trim().PadLeft(4, '0') + " " + postalInfo.Name.Trim());
         }
 
         validated = new MailingAddressRecordExt
         {
             Address = string.Join(' ', addressLines),
-            PostalCode = postal.Code,
-            City = postal.Name,
+            PostalCode = postalInfo.Code,
+            City = postalInfo.Name,
             IsFirstLineCareOfAddress = isCoAddress,
         };
         return true;
@@ -1143,15 +1135,10 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         MatrikkelAddress input,
         [NotNullWhen(true)] out StreetAddressRecord? validated)
     {
-        PostalInfo postal;
-        if (input.PostalArea is null)
+        PostalInfo postalInfo = default;
+        if (input.PostalArea is not null)
         {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/poststed");
-            postal = default;
-        }
-        else
-        {
-            context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postal);
+            context.TryValidateChild(path: "/poststed", input.PostalArea, this, out postalInfo);
         }
 
         string? municipalNumber = null;
@@ -1172,8 +1159,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         {
             MunicipalNumber = municipalNumber,
             MunicipalName = municipalName,
-            PostalCode = postal.Code,
-            City = postal.Name,
+            PostalCode = postalInfo.Code,
+            City = postalInfo.Name,
         };
         return true;
     }
@@ -1184,11 +1171,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
         PostalArea input,
         out PostalInfo validated)
     {
-        if (input.PostalCode is null)
-        {
-            context.AddChildProblem(StdValidationErrors.Required, path: "/postnummer");
-        }
-        else if (!IsDigitsOnly(input.PostalCode))
+        if (input.PostalCode is not null && !IsDigitsOnly(input.PostalCode))
         {
             context.AddChildProblem(ValidationErrors.InvalidValue, path: "/postnummer", detail: $"The postal code '{input.PostalCode}' is not valid. It must contain digits only.");
         }
@@ -1199,9 +1182,8 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
             return false;
         }
 
-        Debug.Assert(input.PostalCode is not null);
         validated = new(
-            Code: input.PostalCode.PadLeft(4, '0'),
+            Code: input.PostalCode?.PadLeft(4, '0'),
             Name: input.PostalName);
         return true;
     }
@@ -1216,7 +1198,7 @@ public sealed class PersonDocumentValidator(ILocationLookup lookup)
     private readonly record struct PersonDeath(DateOnly? DateOfDeath);
 
     private readonly record struct PostalInfo(
-        string Code,
+        string? Code,
         string? Name);
 
     private static bool IsDigitsOnly(ReadOnlySpan<char> str)

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/Enrichers/NprEnricher.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/Enrichers/NprEnricher.cs
@@ -73,7 +73,7 @@ internal sealed class NprEnricher
             ShortName = nprPerson.ShortName,
             Address = nprPerson.Address,
             MailingAddress = nprPerson.MailingAddress,
-            DateOfBirth = nprPerson.DateOfBirth,
+            DateOfBirth = FieldValue.From(nprPerson.DateOfBirth),
             DateOfDeath = FieldValue.From(nprPerson.DateOfDeath),
         };
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/06820298525/npr.json
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/06820298525/npr.json
@@ -1,0 +1,33 @@
+{
+  "identifikasjonsnummer": [
+    {
+      "ajourholdstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "erGjeldende": true,
+      "kilde": "KILDE_DSF",
+      "gyldighetstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "status": "opphoert",
+      "foedselsEllerDNummer": "06820298525",
+      "identifikatortype": "foedselsnummer"
+    }
+  ],
+  "status": [
+    {
+      "ajourholdstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "erGjeldende": true,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Opphøre person",
+      "gyldighetstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "status": "opphoert"
+    }
+  ],
+  "sivilstand": [
+    {
+      "ajourholdstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "erGjeldende": true,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Opphøre person",
+      "gyldighetstidspunkt": "2025-05-26T15:11:22.888+02:00",
+      "sivilstand": "uoppgitt"
+    }
+  ]
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/06820298525/result.validated.json
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/06820298525/result.validated.json
@@ -1,0 +1,13 @@
+{
+  "personIdentifier": "06820298525",
+  "displayName": "Mangler Navn",
+  "firstName": "Mangler",
+  "middleName": null,
+  "lastName": "Navn",
+  "shortName": "Mangler Navn",
+  "address": null,
+  "mailingAddress": null,
+  "dateOfBirth": null,
+  "dateOfDeath": null,
+  "guardians": []
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/27862199486/npr.json
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/27862199486/npr.json
@@ -1,0 +1,227 @@
+{
+  "identifikasjonsnummer": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "status": "iBruk",
+      "foedselsEllerDNummer": "27862199486",
+      "identifikatortype": "foedselsnummer"
+    }
+  ],
+  "status": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "status": "bosatt"
+    }
+  ],
+  "foedsel": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "foedselsdato": "2021-06-27",
+      "foedselsaar": "2021",
+      "foedested": "Alver",
+      "foedekommuneINorge": "4631",
+      "foedeland": "NOR"
+    }
+  ],
+  "foedselINorge": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "foedselsinstitusjonsnavn": "alsver testsykehus",
+      "rekkefoelgenummer": 11
+    }
+  ],
+  "familierelasjon": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:26:49.311004+02:00",
+      "erGjeldende": true,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Farskap",
+      "gyldighetstidspunkt": "2021-06-29T13:26:49.240286+02:00",
+      "relatertPersonUtenFolkeregisteridentifikator": {
+        "navn": { "fornavn": "GLAD", "etternavn": "FISK" },
+        "foedselsdato": "1990-04-17"
+      },
+      "relatertPersonsRolle": "far",
+      "minRolleForPerson": "barn"
+    },
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "relatertPerson": "30839498094",
+      "relatertPersonsRolle": "mor",
+      "minRolleForPerson": "barn"
+    }
+  ],
+  "sivilstand": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "sivilstand": "ugift"
+    }
+  ],
+  "navn": [
+    {
+      "ajourholdstidspunkt": "2022-11-30T10:31:45.189432+01:00",
+      "erGjeldende": true,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Navn",
+      "gyldighetstidspunkt": "2022-11-30T10:31:45.173127+01:00",
+      "fornavn": "GULAKTIG",
+      "etternavn": "ABBOR"
+    },
+    {
+      "ajourholdstidspunkt": "2021-12-29T00:31:37.454503+01:00",
+      "erGjeldende": false,
+      "kilde": "FREG automatisk",
+      "aarsak": "Navn på barn",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "fornavn": "VASSEN*PIKE",
+      "etternavn": "ABBOR"
+    }
+  ],
+  "bostedsadresse": [
+    {
+      "ajourholdstidspunkt": "2025-08-14T20:27:40.101171342+02:00",
+      "erGjeldende": true,
+      "kilde": "Matrikkelen",
+      "aarsak": "Adresseoppdatering",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "vegadresse": {
+        "kommunenummer": "3418",
+        "bruksenhetsnummer": "H0101",
+        "bruksenhetstype": "bolig",
+        "adressenavn": "Granittvegen",
+        "adressenummer": { "husnummer": "9" },
+        "adressekode": "01083",
+        "poststed": { "poststedsnavn": "FLISA", "postnummer": "2270" }
+      },
+      "adresseIdentifikatorFraMatrikkelen": "224390853",
+      "adressegradering": "ugradert",
+      "flyttedato": "2021-06-27",
+      "grunnkrets": 207,
+      "stemmekrets": 1,
+      "skolekrets": 2,
+      "kirkekrets": 1
+    },
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.398223+02:00",
+      "erGjeldende": false,
+      "kilde": "DP055_veinummer",
+      "aarsak": "Årsakskode fra DSF: ",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "vegadresse": {
+        "kommunenummer": "3418",
+        "bruksenhetsnummer": "H0101",
+        "bruksenhetstype": "bolig",
+        "adressenavn": "Granittvegen",
+        "adressenummer": { "husnummer": "9" },
+        "adressekode": "1083",
+        "poststed": { "poststedsnavn": "FLISA", "postnummer": "2270" }
+      },
+      "adresseIdentifikatorFraMatrikkelen": "224390853",
+      "adressegradering": "ugradert",
+      "flyttedato": "2021-06-27",
+      "grunnkrets": 207,
+      "stemmekrets": 2,
+      "skolekrets": 2,
+      "kirkekrets": 1
+    }
+  ],
+  "postadresse": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "adressegradering": "ugradert",
+      "postadresseIFrittFormat": {
+        "adresselinje": ["Granittvegen", "2270 FLISA", "Norge"]
+      }
+    }
+  ],
+  "foreldreansvar": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:35:07.937611+02:00",
+      "erGjeldende": false,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Farskap",
+      "gyldighetstidspunkt": "2021-06-29T13:26:49.240286+02:00",
+      "opphoerstidspunkt": "2021-06-29T00:00:00+02:00",
+      "ansvar": "felles",
+      "ansvarssubjekt": "27862199486",
+      "ansvarligUtenIdentifikator": {
+        "navn": { "fornavn": "GLAD", "etternavn": "FISK" },
+        "foedselsdato": "1990-04-17"
+      }
+    },
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:35:07.937611+02:00",
+      "erGjeldende": false,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Farskap",
+      "gyldighetstidspunkt": "2021-06-29T13:26:49.240286+02:00",
+      "opphoerstidspunkt": "2021-06-29T00:00:00+02:00",
+      "ansvar": "felles",
+      "ansvarssubjekt": "27862199486",
+      "ansvarlig": "30839498094"
+    },
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:35:07.937611+02:00",
+      "erGjeldende": true,
+      "kilde": "folkeregistermyndigheten",
+      "aarsak": "Foreldreansvar",
+      "gyldighetstidspunkt": "2021-06-29T00:00:00+02:00",
+      "ansvar": "far",
+      "ansvarssubjekt": "27862199486",
+      "ansvarligUtenIdentifikator": {
+        "navn": { "fornavn": "GLAD", "etternavn": "FISK" },
+        "foedselsdato": "1990-04-17"
+      }
+    },
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:26:49.310286+02:00",
+      "erGjeldende": false,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "opphoerstidspunkt": "2021-06-29T13:26:49.240286+02:00",
+      "ansvar": "mor",
+      "ansvarssubjekt": "27862199486",
+      "ansvarlig": "30839498094"
+    }
+  ],
+  "statsborgerskap": [
+    {
+      "ajourholdstidspunkt": "2021-06-29T13:25:14.397673+02:00",
+      "erGjeldende": true,
+      "kilde": "forelder",
+      "aarsak": "Fødsel",
+      "gyldighetstidspunkt": "2021-06-27T00:00:00+02:00",
+      "statsborgerskap": "NOR",
+      "ervervsdato": "2021-06-27"
+    }
+  ]
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/27862199486/result.validated.json
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Tests/Testdata/Npr/Persons/valid/27862199486/result.validated.json
@@ -1,0 +1,25 @@
+{
+  "personIdentifier": "27862199486",
+  "displayName": "GULAKTIG ABBOR",
+  "firstName": "GULAKTIG",
+  "middleName": null,
+  "lastName": "ABBOR",
+  "shortName": "ABBOR GULAKTIG",
+  "address": {
+    "municipalNumber": "3418",
+    "municipalName": "ÅSNES",
+    "streetName": "Granittvegen",
+    "houseNumber": "9",
+    "houseLetter": null,
+    "postalCode": "2270",
+    "city": "FLISA"
+  },
+  "mailingAddress": {
+    "address": "Granittvegen 2270 FLISA Norge",
+    "postalCode": null,
+    "city": null
+  },
+  "dateOfBirth": "2021-06-27",
+  "dateOfDeath": null,
+  "guardians": []
+}


### PR DESCRIPTION
Makes the following optional:
* Person name
* Person birth date
* Post code on addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or missing birth date information in person records.

* **Tests**
  * Added test data fixtures to validate person records with optional demographic fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->