### PR TITLE
feat: create party-id

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Parties/PersistenceFeatureFlag.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Parties/PersistenceFeatureFlag.cs
@@ -1,0 +1,13 @@
+namespace Altinn.Register.Core.Parties;
+
+/// <summary>
+/// Feature flags for persistence operations.
+/// </summary>
+public enum PersistenceFeatureFlag
+    : uint
+{
+    /// <summary>
+    /// Indicates that creating new party IDs is allowed.
+    /// </summary>
+    CreatePartyId = 1,
+}

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Microsoft.Extensions.Hosting/RegisterPersistenceExtensions.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Microsoft.Extensions.Hosting/RegisterPersistenceExtensions.cs
@@ -273,6 +273,12 @@ public static class RegisterPersistenceExtensions
             _ => null,
         }));
 
+        builder.MapEnum<PersistenceFeatureFlag>("register.db_feature_flag", new EnumNameTranslator<PersistenceFeatureFlag>(static value => value switch
+        {
+            PersistenceFeatureFlag.CreatePartyId => "create_party_id",
+            _ => null,
+        }));
+
         builder.MapComposite<MailingAddressRecord>("register.co_mailing_address", new CompositeNameTranslator<MailingAddressRecord>(static member => member.Name switch
         {
             nameof(MailingAddressRecord.Address) => "address",

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/00-saga-state-updated-index.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/00-saga-state-updated-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS saga_state_updated_idx ON register.saga_state (updated);

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/01-party-inc-id-seq.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/01-party-inc-id-seq.sql
@@ -1,0 +1,3 @@
+CREATE SEQUENCE register.party_inc_id_seq
+AS bigint
+START WITH 1000000001; -- 1_000_000_001

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/02-feature-flags.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/02-feature-flags.sql
@@ -1,0 +1,3 @@
+CREATE TYPE register.db_feature_flag AS ENUM (
+  'create_party_id'
+);

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/03-upsert-party.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/03-upsert-party.sql
@@ -1,0 +1,191 @@
+CREATE OR REPLACE FUNCTION register.upsert_party(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
+  INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
+  INOUT p_id register.party.id%TYPE,
+  INOUT p_ext_urn register.party.ext_urn%TYPE,
+  INOUT p_user_ids bigint[], -- The user_ids is considered unset if it is NULL
+  IN s_username boolean,
+  INOUT p_username text,
+  INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
+  INOUT p_display_name register.party.display_name%TYPE,
+  INOUT p_person_identifier register.party.person_identifier%TYPE,
+  INOUT p_organization_identifier register.party.organization_identifier%TYPE,
+  INOUT p_created register.party.created%TYPE,
+  INOUT p_updated register.party.updated%TYPE,
+  IN s_is_deleted boolean,
+  INOUT p_is_deleted register.party.is_deleted%TYPE,
+  IN s_deleted_at boolean,
+  INOUT p_deleted_at register.party.deleted_at%TYPE,
+  IN s_owner boolean,
+  INOUT p_owner register.party.owner%TYPE,
+  OUT o_version_id register.party.version_id%TYPE
+)
+AS $$
+DECLARE
+  o_party register.party%ROWTYPE;
+BEGIN
+  -- Validate some parameters
+  IF s_uuid <> s_id THEN
+    RAISE EXCEPTION 'Parameters "s_uuid" and "s_id" must be the same. Either both are known or none of them are.'
+      USING ERRCODE = 'ZZ001'
+          , SCHEMA = 'register'
+          , TABLE = 'party';
+  END IF;
+
+  IF NOT s_uuid AND p_user_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'Parameter "p_user_ids" cannot be set without "s_uuid"'
+      USING ERRCODE = 'ZZ001'
+          , SCHEMA = 'register'
+          , TABLE = 'party';
+  END IF;
+
+  -- Get existing party by UUID if it exists
+  SELECT p.*
+  INTO o_party
+  FROM register.party p
+  WHERE (s_uuid AND p.uuid = p_uuid)
+     OR (NOT s_uuid AND p_person_identifier IS NOT NULL AND p.person_identifier = p_person_identifier)
+     OR (NOT s_uuid AND p_organization_identifier IS NOT NULL AND p.organization_identifier = p_organization_identifier)
+  LIMIT 1
+  FOR NO KEY UPDATE;
+
+  -- If the party does not exist, insert it and return it
+  IF NOT FOUND THEN
+    -- If the uuid/id is not provided, find the existing party by alternate keys (person_identifier or organization_identifier), or generate new ones
+    IF NOT s_uuid THEN
+      -- We've already attempted to find the party by alternate keys, so this means it's a new party that doesn't have a uuid/id yet.
+      IF NOT 'create_party_id' = ANY(p_flags) THEN
+        RAISE EXCEPTION 'Creating new party-ids is not allowed without "create_party_id" feature flag'
+          USING ERRCODE = 'ZZ001'
+              , SCHEMA = 'register'
+              , TABLE = 'party';
+      END IF;
+
+      p_uuid := gen_random_uuid();
+      p_id := nextval('register.party_inc_id_seq');
+
+      IF p_party_type IN('person', 'self-identified-user') THEN
+        p_user_ids := ARRAY[p_id];
+      END IF;
+    END IF;
+
+    -- Assign defaults to optional fields
+    IF NOT s_is_deleted THEN
+      p_is_deleted := FALSE;
+    END IF;
+
+    IF NOT s_deleted_at THEN
+      p_deleted_at := NULL;
+    END IF;
+
+    IF NOT s_owner THEN
+      p_owner := NULL;
+    END IF;
+
+    -- Validate required fields
+    IF NOT s_display_name THEN
+      RAISE EXCEPTION 'null value in column "display_name" of relation "party" violates not-null constraint'
+        USING ERRCODE = '23502'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'display_name';
+    END IF;
+
+    -- Insert new party
+    INSERT INTO register.party (uuid, id, party_type, ext_urn, display_name, person_identifier, organization_identifier, created, updated, is_deleted, deleted_at, "owner")
+    VALUES (p_uuid, p_id, p_party_type, p_ext_urn, p_display_name, p_person_identifier, p_organization_identifier, p_created, p_updated, p_is_deleted, p_deleted_at, p_owner)
+    RETURNING * INTO o_party;
+
+  ELSE
+    -- Validate that the updated party does not modify any immutable fields
+    IF s_id AND o_party.id <> p_id THEN
+      RAISE EXCEPTION 'Cannot update immutable field "id" on party, existing: %, updated: %, party_uuid: %', o_party.id, p_id, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'id';
+    END IF;
+
+    IF o_party.party_type <> p_party_type THEN
+      RAISE EXCEPTION 'Cannot update immutable field "party_type" on party, existing: %, updated: %, party_uuid: %', o_party.party_type, p_party_type, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'party_type';
+    END IF;
+
+    IF o_party.person_identifier <> p_person_identifier THEN
+      RAISE EXCEPTION 'Cannot update immutable field "person_identifier" on party, existing: %, updated: %, party_uuid: %', o_party.person_identifier, p_person_identifier, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'person_identifier';
+    END IF;
+
+    IF o_party.organization_identifier <> p_organization_identifier THEN
+      RAISE EXCEPTION 'Cannot update immutable field "organization_identifier" on party, existing: %, updated: %, party_uuid: %', o_party.organization_identifier, p_organization_identifier, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'organization_identifier';
+    END IF;
+
+    IF s_owner THEN
+      IF o_party.owner <> p_owner THEN
+        RAISE EXCEPTION 'Cannot update immutable field "owner" on party, existing: %, updated: %, party_uuid: %', o_party.owner, p_owner, p_uuid
+          USING ERRCODE = 'ZZ001'
+              , SCHEMA = 'register'
+              , TABLE = 'party'
+              , COLUMN = 'owner';
+      END IF;
+    END IF;
+
+    -- Set expected fields based on lookup now allowing alternate keys
+    p_uuid := o_party.uuid;
+    p_id := o_party.id;
+
+    UPDATE register.party p
+    SET display_name = CASE WHEN s_display_name THEN p_display_name ELSE p.display_name END
+      , updated = p_updated
+      , is_deleted = CASE WHEN s_is_deleted THEN p_is_deleted ELSE p.is_deleted END
+      , deleted_at = CASE WHEN s_deleted_at THEN p_deleted_at ELSE p.deleted_at END
+      , ext_urn = p_ext_urn
+    WHERE p.uuid = p_uuid
+    RETURNING * INTO o_party;
+  END IF;
+
+  -- If the party is deleted, clear username such that it can be reused by a person who absorbed a self-identified-user
+  IF p_is_deleted THEN
+    p_username := NULL;
+  END IF;
+
+  -- Upsert the user
+  IF p_user_ids IS NOT NULL THEN
+    SELECT *
+    FROM register.upsert_user(p_uuid, p_is_deleted, p_user_ids, s_username, p_username)
+    INTO p_user_ids, p_username;
+  ELSEIF p_username IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot set username without user_ids, party_uuid: %', p_uuid
+      USING ERRCODE = 'ZZ001'
+          , SCHEMA = 'register'
+          , TABLE = 'party';
+  END IF;
+
+  p_uuid := o_party.uuid;
+  p_id := o_party.id;
+  p_ext_urn := o_party.ext_urn;
+  p_party_type := o_party.party_type;
+  p_display_name := o_party.display_name;
+  p_person_identifier := o_party.person_identifier;
+  p_organization_identifier := o_party.organization_identifier;
+  p_created := o_party.created;
+  p_updated := o_party.updated;
+  p_is_deleted := o_party.is_deleted;
+  p_deleted_at := o_party.deleted_at;
+  p_owner := o_party.owner;
+  o_version_id := o_party.version_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/04-upsert-org.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/04-upsert-org.sql
@@ -1,0 +1,180 @@
+CREATE OR REPLACE FUNCTION register.upsert_party_org(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
+  INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
+  INOUT p_id register.party.id%TYPE,
+  INOUT p_ext_urn register.party.ext_urn%TYPE,
+  INOUT p_user_ids bigint[],
+  IN s_username boolean,
+  INOUT p_username text,
+  INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
+  INOUT p_display_name register.party.display_name%TYPE,
+  INOUT p_person_identifier register.party.person_identifier%TYPE,
+  INOUT p_organization_identifier register.party.organization_identifier%TYPE,
+  INOUT p_created register.party.created%TYPE,
+  INOUT p_updated register.party.updated%TYPE,
+  IN s_is_deleted boolean,
+  INOUT p_is_deleted register.party.is_deleted%TYPE,
+  IN s_deleted_at boolean,
+  INOUT p_deleted_at register.party.deleted_at%TYPE,
+  IN s_owner boolean,
+  INOUT p_owner register.party.owner%TYPE,
+  IN s_unit_status boolean,
+  INOUT p_unit_status register.organization.unit_status%TYPE,
+  IN s_unit_type boolean,
+  INOUT p_unit_type register.organization.unit_type%TYPE,
+  IN s_telephone_number boolean,
+  INOUT p_telephone_number register.organization.telephone_number%TYPE,
+  IN s_mobile_number boolean,
+  INOUT p_mobile_number register.organization.mobile_number%TYPE,
+  IN s_fax_number boolean,
+  INOUT p_fax_number register.organization.fax_number%TYPE,
+  IN s_email_address boolean,
+  INOUT p_email_address register.organization.email_address%TYPE,
+  IN s_internet_address boolean,
+  INOUT p_internet_address register.organization.internet_address%TYPE,
+  IN s_mailing_address boolean,
+  INOUT p_mailing_address register.organization.mailing_address%TYPE,
+  IN s_business_address boolean,
+  INOUT p_business_address register.organization.business_address%TYPE,
+  IN s_source boolean,
+  INOUT p_source register.organization.source%TYPE,
+  OUT o_version_id register.party.version_id%TYPE
+)
+AS $$
+DECLARE
+  o_org register.organization%ROWTYPE;
+BEGIN
+  ASSERT p_party_type = 'organization', 'Party must be of type "organization"';
+
+  -- Upsert the party
+  SELECT *
+  FROM register.upsert_party(
+    p_flags,
+    s_uuid,
+    p_uuid,
+    s_id,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    s_username, p_username,
+    p_party_type,
+    s_display_name,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    s_is_deleted, p_is_deleted,
+    s_deleted_at, p_deleted_at,
+    s_owner, p_owner)
+  INTO
+    p_uuid,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    p_username,
+    p_party_type,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    p_is_deleted,
+    p_deleted_at,
+    p_owner,
+    o_version_id;
+
+  -- Get existing organization by UUID if it exists
+  SELECT o.*
+  INTO o_org
+  FROM register.organization o
+  WHERE o.uuid = p_uuid
+  FOR NO KEY UPDATE;
+
+  -- If the organization does not exist, insert it and return it
+  IF NOT FOUND THEN
+    -- Assign defaults to optional fields
+    IF NOT s_unit_status THEN
+      p_unit_status := NULL;
+    END IF;
+
+    IF NOT s_unit_type THEN
+      p_unit_type := NULL;
+    END IF;
+
+    IF NOT s_telephone_number THEN
+      p_telephone_number := NULL;
+    END IF;
+
+    IF NOT s_mobile_number THEN
+      p_mobile_number := NULL;
+    END IF;
+
+    IF NOT s_fax_number THEN
+      p_fax_number := NULL;
+    END IF;
+
+    IF NOT s_email_address THEN
+      p_email_address := NULL;
+    END IF;
+
+    IF NOT s_internet_address THEN
+      p_internet_address := NULL;
+    END IF;
+
+    IF NOT s_mailing_address THEN
+      p_mailing_address := NULL;
+    END IF;
+
+    IF NOT s_business_address THEN
+      p_business_address := NULL;
+    END IF;
+
+    -- Validate required fields
+    IF NOT s_source THEN
+      RAISE EXCEPTION 'null value in column "source" of relation "organization" violates not-null constraint'
+        USING ERRCODE = '23502'
+            , SCHEMA = 'register'
+            , TABLE = 'organization'
+            , COLUMN = 'source';
+    END IF;
+
+    INSERT INTO register.organization ("uuid", unit_status, unit_type, telephone_number, mobile_number, fax_number, email_address, internet_address, mailing_address, business_address, source)
+    VALUES (p_uuid, p_unit_status, p_unit_type, p_telephone_number, p_mobile_number, p_fax_number, p_email_address, p_internet_address, p_mailing_address, p_business_address, p_source)
+    RETURNING * INTO o_org;
+
+  ELSE
+    -- Update the organization
+    UPDATE register.organization o
+    SET unit_status = CASE WHEN s_unit_status THEN p_unit_status ELSE o.unit_status END
+      , unit_type = CASE WHEN s_unit_type THEN p_unit_type ELSE o.unit_type END
+      , telephone_number = CASE WHEN s_telephone_number THEN p_telephone_number ELSE o.telephone_number END
+      , mobile_number = CASE WHEN s_mobile_number THEN p_mobile_number ELSE o.mobile_number END
+      , fax_number = CASE WHEN s_fax_number THEN p_fax_number ELSE o.fax_number END
+      , email_address = CASE WHEN s_email_address THEN p_email_address ELSE o.email_address END
+      , internet_address = CASE WHEN s_internet_address THEN p_internet_address ELSE o.internet_address END
+      , mailing_address = CASE WHEN s_mailing_address THEN p_mailing_address ELSE o.mailing_address END
+      , business_address = CASE WHEN s_business_address THEN p_business_address ELSE o.business_address END
+      , source = CASE
+          WHEN s_source THEN p_source
+          ELSE o.source
+        END
+    WHERE o.uuid = p_uuid
+    RETURNING * INTO o_org;
+  END IF;
+
+  p_unit_status := o_org.unit_status;
+  p_unit_type := o_org.unit_type;
+  p_telephone_number := o_org.telephone_number;
+  p_mobile_number := o_org.mobile_number;
+  p_fax_number := o_org.fax_number;
+  p_email_address := o_org.email_address;
+  p_internet_address := o_org.internet_address;
+  p_mailing_address := o_org.mailing_address;
+  p_business_address := o_org.business_address;
+  p_source := o_org.source;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/05-upsert-pers.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/05-upsert-pers.sql
@@ -1,0 +1,172 @@
+CREATE OR REPLACE FUNCTION register.upsert_party_pers(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
+  INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
+  INOUT p_id register.party.id%TYPE,
+  INOUT p_ext_urn register.party.ext_urn%TYPE,
+  INOUT p_user_ids bigint[],
+  IN s_username boolean,
+  INOUT p_username text,
+  INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
+  INOUT p_display_name register.party.display_name%TYPE,
+  INOUT p_person_identifier register.party.person_identifier%TYPE,
+  INOUT p_organization_identifier register.party.organization_identifier%TYPE,
+  INOUT p_created register.party.created%TYPE,
+  INOUT p_updated register.party.updated%TYPE,
+  IN s_is_deleted boolean,
+  INOUT p_is_deleted register.party.is_deleted%TYPE,
+  IN s_deleted_at boolean,
+  INOUT p_deleted_at register.party.deleted_at%TYPE,
+  IN s_owner boolean,
+  INOUT p_owner register.party.owner%TYPE,
+  IN s_first_name boolean,
+  INOUT p_first_name register.person.first_name%TYPE,
+  IN s_middle_name boolean,
+  INOUT p_middle_name register.person.middle_name%TYPE,
+  IN s_last_name boolean,
+  INOUT p_last_name register.person.last_name%TYPE,
+  IN s_short_name boolean,
+  INOUT p_short_name register.person.short_name%TYPE,
+  IN s_date_of_birth boolean,
+  INOUT p_date_of_birth register.person.date_of_birth%TYPE,
+  IN s_date_of_death boolean,
+  INOUT p_date_of_death register.person.date_of_death%TYPE,
+  IN s_address boolean,
+  INOUT p_address register.person.address%TYPE,
+  IN s_mailing_address boolean,
+  INOUT p_mailing_address register.person.mailing_address%TYPE,
+  IN s_source boolean,
+  INOUT p_source register.person.source%TYPE,
+  OUT o_version_id register.party.version_id%TYPE
+)
+AS $$
+DECLARE
+  o_pers register.person%ROWTYPE;
+BEGIN
+  ASSERT p_party_type = 'person', 'Party must be of type "person"';
+
+  -- Upsert the party
+  SELECT *
+  FROM register.upsert_party(
+    p_flags,
+    s_uuid,
+    p_uuid,
+    s_id,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    s_username, p_username,
+    p_party_type,
+    s_display_name,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    s_is_deleted, p_is_deleted,
+    s_deleted_at, p_deleted_at,
+    s_owner, p_owner)
+  INTO
+    p_uuid,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    p_username,
+    p_party_type,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    p_is_deleted,
+    p_deleted_at,
+    p_owner,
+    o_version_id;
+
+  -- Get existing person by UUID if it exists
+  SELECT p.*
+  INTO o_pers
+  FROM register.person p
+  WHERE p.uuid = p_uuid
+  FOR NO KEY UPDATE;
+
+  -- If the person does not exist, insert it and return it
+  IF NOT FOUND THEN
+    -- Assign defaults to optional fields
+    IF NOT s_first_name THEN
+      p_first_name := NULL;
+    END IF;
+
+    IF NOT s_middle_name THEN
+      p_middle_name := NULL;
+    END IF;
+
+    IF NOT s_last_name THEN
+      p_last_name := NULL;
+    END IF;
+
+    IF NOT s_short_name THEN
+      p_short_name := NULL;
+    END IF;
+
+    IF NOT s_date_of_birth THEN
+      p_date_of_birth := NULL;
+    END IF;
+
+    IF NOT s_date_of_death THEN
+      p_date_of_death := NULL;
+    END IF;
+
+    IF NOT s_address THEN
+      p_address := NULL;
+    END IF;
+
+    IF NOT s_mailing_address THEN
+      p_mailing_address := NULL;
+    END IF;
+
+    -- Validate required fields
+    IF NOT s_source THEN
+      RAISE EXCEPTION 'null value in column "source" of relation "person" violates not-null constraint'
+        USING ERRCODE = '23502'
+            , SCHEMA = 'register'
+            , TABLE = 'person'
+            , COLUMN = 'source';
+    END IF;
+
+    INSERT INTO register.person ("uuid", first_name, middle_name, last_name, short_name, date_of_birth, date_of_death, address, mailing_address, source)
+    VALUES (p_uuid, p_first_name, p_middle_name, p_last_name, p_short_name, p_date_of_birth, p_date_of_death, p_address, p_mailing_address, p_source)
+    RETURNING * INTO o_pers;
+
+  ELSE
+    -- Update the person
+    UPDATE register.person p
+    SET first_name = CASE WHEN s_first_name THEN p_first_name ELSE p.first_name END
+      , middle_name = CASE WHEN s_middle_name THEN p_middle_name ELSE p.middle_name END
+      , last_name = CASE WHEN s_last_name THEN p_last_name ELSE p.last_name END
+      , short_name = CASE WHEN s_short_name THEN p_short_name ELSE p.short_name END
+      , date_of_birth = CASE WHEN s_date_of_birth THEN p_date_of_birth ELSE p.date_of_birth END
+      , date_of_death = CASE WHEN s_date_of_death THEN p_date_of_death ELSE p.date_of_death END
+      , address = CASE WHEN s_address THEN p_address ELSE p.address END
+      , mailing_address = CASE WHEN s_mailing_address THEN p_mailing_address ELSE p.mailing_address END
+      , source = CASE
+          WHEN s_source THEN p_source
+          ELSE p.source
+        END
+    WHERE p.uuid = p_uuid
+    RETURNING * INTO o_pers;
+  END IF;
+
+  p_first_name := o_pers.first_name;
+  p_middle_name := o_pers.middle_name;
+  p_last_name := o_pers.last_name;
+  p_short_name := o_pers.short_name;
+  p_date_of_birth := o_pers.date_of_birth;
+  p_date_of_death := o_pers.date_of_death;
+  p_address := o_pers.address;
+  p_mailing_address := o_pers.mailing_address;
+  p_source := o_pers.source;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/06-upsert-self-identified-user.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/06-upsert-self-identified-user.sql
@@ -1,0 +1,154 @@
+CREATE OR REPLACE FUNCTION register.upsert_self_identified_user(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
+  INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
+  INOUT p_id register.party.id%TYPE,
+  INOUT p_ext_urn register.party.ext_urn%TYPE,
+  INOUT p_user_ids bigint[],
+  IN s_username boolean,
+  INOUT p_username text,
+  INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
+  INOUT p_display_name register.party.display_name%TYPE,
+  INOUT p_person_identifier register.party.person_identifier%TYPE,
+  INOUT p_organization_identifier register.party.organization_identifier%TYPE,
+  INOUT p_created register.party.created%TYPE,
+  INOUT p_updated register.party.updated%TYPE,
+  IN s_is_deleted boolean,
+  INOUT p_is_deleted register.party.is_deleted%TYPE,
+  IN s_deleted_at boolean,
+  INOUT p_deleted_at register.party.deleted_at%TYPE,
+  IN s_owner boolean,
+  INOUT p_owner register.party.owner%TYPE,
+  INOUT p_self_identified_user_type register.self_identified_user."type"%TYPE,
+  IN s_self_identified_email boolean,
+  INOUT p_self_identified_email register.self_identified_user.email%TYPE,
+  IN s_self_identified_ext_ref boolean,
+  INOUT p_self_identified_ext_ref register.self_identified_user.ext_ref%TYPE,
+  OUT o_version_id register.party.version_id%TYPE
+)
+AS $$
+DECLARE
+  o_self_identified_user register.self_identified_user%ROWTYPE;
+BEGIN
+  ASSERT p_party_type = 'self-identified-user', 'Party must be of type "self-identified-user"';
+  CASE
+    WHEN p_self_identified_user_type = 'legacy' THEN
+      ASSERT starts_with(p_ext_urn, 'urn:altinn:person:legacy-selfidentified:'), 'Invalid ext_urn format for legacy self-identified user';
+    WHEN p_self_identified_user_type = 'edu' THEN
+      ASSERT p_ext_urn IS NULL, 'ext_urn must be NULL for edu self-identified user';
+    WHEN p_self_identified_user_type = 'idporten-email' THEN
+      ASSERT starts_with(p_ext_urn, 'urn:altinn:person:idporten-email:'), 'Invalid ext_urn format for idporten-email self-identified user';
+    ELSE
+      RAISE EXCEPTION 'Unknown self-identified user type: %', p_self_identified_user_type
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'self_identified_user'
+            , COLUMN = 'type';
+  END CASE;
+
+  -- Upsert the party
+  SELECT *
+  FROM register.upsert_party(
+    p_flags,
+    s_uuid,
+    p_uuid,
+    s_id,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    s_username,
+    p_username,
+    p_party_type,
+    s_display_name,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    s_is_deleted,
+    p_is_deleted,
+    s_deleted_at,
+    p_deleted_at,
+    s_owner,
+    p_owner)
+  INTO
+    p_uuid,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    p_username,
+    p_party_type,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    p_is_deleted,
+    p_deleted_at,
+    p_owner,
+    o_version_id;
+
+  -- Get existing system_user by UUID if it exists
+  SELECT u.*
+  INTO o_self_identified_user
+  FROM register."self_identified_user" u
+  WHERE u.uuid = p_uuid
+  FOR NO KEY UPDATE;
+
+  -- If the system_user does not exist, insert it and return it
+  IF NOT FOUND THEN
+    -- Assign defaults to optional fields
+    IF NOT s_self_identified_email THEN
+      p_self_identified_email := NULL;
+    END IF;
+
+    IF NOT s_self_identified_ext_ref THEN
+      p_self_identified_ext_ref := NULL;
+    END IF;
+
+    INSERT INTO register."self_identified_user" ("uuid", "type", "email", "ext_ref")
+    VALUES (p_uuid, p_self_identified_user_type, p_self_identified_email, p_self_identified_ext_ref)
+    RETURNING * INTO o_self_identified_user;
+
+  ELSE
+    -- Validate that the updated party does not modify any immutable fields
+    IF o_self_identified_user."type" <> p_self_identified_user_type THEN
+      RAISE EXCEPTION 'Cannot update immutable field "type" on self_identified_user, existing: %, updated: %, party_uuid: %', o_self_identified_user."type", p_self_identified_user_type, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'self_identified_user'
+            , COLUMN = 'type';
+    END IF;
+
+    IF s_self_identified_email AND o_self_identified_user."email" IS DISTINCT FROM p_self_identified_email THEN
+      RAISE EXCEPTION 'Cannot update immutable field "email" on self_identified_user, existing: %, updated: %, party_uuid: %', o_self_identified_user."email", p_self_identified_email, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'self_identified_user'
+            , COLUMN = 'email';
+    END IF;
+
+    IF s_self_identified_ext_ref
+      AND o_self_identified_user.ext_ref IS NOT NULL
+      AND o_self_identified_user.ext_ref IS DISTINCT FROM p_self_identified_ext_ref
+    THEN
+      RAISE EXCEPTION 'Cannot update immutable field "ext_ref" on self_identified_user, existing: %, updated: %, party_uuid: %', o_self_identified_user.ext_ref, p_self_identified_ext_ref, p_uuid
+        USING ERRCODE = 'ZZ001'
+            , SCHEMA = 'register'
+            , TABLE = 'self_identified_user'
+            , COLUMN = 'ext_ref';
+    END IF;
+
+    UPDATE register.self_identified_user
+    SET ext_ref = CASE WHEN s_self_identified_ext_ref THEN COALESCE(o_self_identified_user.ext_ref, p_self_identified_ext_ref) ELSE o_self_identified_user.ext_ref END
+    WHERE uuid = p_uuid
+    RETURNING * INTO o_self_identified_user;
+  END IF;
+
+  p_self_identified_user_type := o_self_identified_user."type";
+  p_self_identified_email := o_self_identified_user."email";
+  p_self_identified_ext_ref := o_self_identified_user.ext_ref;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/07-upsert-system-user.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/07-upsert-system-user.sql
@@ -1,0 +1,98 @@
+CREATE OR REPLACE FUNCTION register.upsert_system_user(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
+  INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
+  INOUT p_id register.party.id%TYPE,
+  INOUT p_ext_urn register.party.ext_urn%TYPE,
+  INOUT p_user_ids bigint[],
+  IN s_username boolean,
+  INOUT p_username text,
+  INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
+  INOUT p_display_name register.party.display_name%TYPE,
+  INOUT p_person_identifier register.party.person_identifier%TYPE,
+  INOUT p_organization_identifier register.party.organization_identifier%TYPE,
+  INOUT p_created register.party.created%TYPE,
+  INOUT p_updated register.party.updated%TYPE,
+  IN s_is_deleted boolean,
+  INOUT p_is_deleted register.party.is_deleted%TYPE,
+  IN s_deleted_at boolean,
+  INOUT p_deleted_at register.party.deleted_at%TYPE,
+  IN s_owner boolean,
+  INOUT p_owner register.party.owner%TYPE,
+  INOUT p_system_user_type register.system_user."type"%TYPE,
+  OUT o_version_id register.party.version_id%TYPE
+)
+AS $$
+DECLARE
+  o_system_user register.system_user%ROWTYPE;
+BEGIN
+  ASSERT p_party_type = 'system-user', 'Party must be of type "system-user"';
+
+  -- Upsert the party
+  SELECT *
+  FROM register.upsert_party(
+    p_flags,
+    s_uuid,
+    p_uuid,
+    s_id,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    s_username,
+    p_username,
+    p_party_type,
+    s_display_name,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    s_is_deleted,
+    p_is_deleted,
+    s_deleted_at,
+    p_deleted_at,
+    s_owner,
+    p_owner)
+  INTO
+    p_uuid,
+    p_id,
+    p_ext_urn,
+    p_user_ids,
+    p_username,
+    p_party_type,
+    p_display_name,
+    p_person_identifier,
+    p_organization_identifier,
+    p_created,
+    p_updated,
+    p_is_deleted,
+    p_deleted_at,
+    p_owner,
+    o_version_id;
+
+  -- Get existing system_user by UUID if it exists
+  SELECT u.*
+  INTO o_system_user
+  FROM register."system_user" u
+  WHERE u.uuid = p_uuid
+  FOR NO KEY UPDATE;
+
+  -- If the system_user does not exist, insert it and return it
+  IF NOT FOUND THEN
+    INSERT INTO register."system_user" ("uuid", "type")
+    VALUES (p_uuid, p_system_user_type)
+    RETURNING * INTO o_system_user;
+
+  ELSE
+    -- Update the system_user
+    UPDATE register."system_user" u
+    SET "type" = p_system_user_type
+    WHERE u.uuid = p_uuid
+    RETURNING * INTO o_system_user;
+  END IF;
+
+  p_system_user_type := o_system_user."type";
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.UpsertPartyQuery.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.UpsertPartyQuery.cs
@@ -37,13 +37,15 @@ internal partial class PostgreSqlPartyPersistence
         /// </summary>
         /// <param name="conn">The connection.</param>
         /// <param name="party">The party.</param>
+        /// <param name="flags">The persistence feature-flags to use for this operation.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
         /// <returns>The updated party.</returns>
         public static ValueTask<Result<PartyRecord>> UpsertParty(
             NpgsqlConnection conn,
             PartyRecord party,
+            PersistenceFeatureFlag[] flags,
             CancellationToken cancellationToken)
-            => UpsertParties(conn, new AsyncSingleton(party), cancellationToken)
+            => UpsertParties(conn, new AsyncSingleton(party), flags, cancellationToken)
                 .FirstAsync(cancellationToken);
 
         /// <summary>
@@ -51,11 +53,13 @@ internal partial class PostgreSqlPartyPersistence
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <param name="parties">The parties.</param>
+        /// <param name="flags">The persistence feature-flags to use for this operation.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
         /// <returns>The updated parties.</returns>
         public static async IAsyncEnumerable<Result<PartyRecord>> UpsertParties(
             NpgsqlConnection connection,
             IAsyncEnumerable<PartyRecord> parties,
+            PersistenceFeatureFlag[] flags,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             var batch = connection.CreateBatch();
@@ -67,23 +71,23 @@ internal partial class PostgreSqlPartyPersistence
                     switch (party)
                     {
                         case PersonRecord person:
-                            _person.EnqueuePartyUpsert(batch, person);
+                            _person.EnqueuePartyUpsert(batch, person, flags);
                             break;
 
                         case OrganizationRecord org:
-                            _org.EnqueuePartyUpsert(batch, org);
+                            _org.EnqueuePartyUpsert(batch, org, flags);
                             break;
 
                         case SelfIdentifiedUserRecord siu:
-                            _si.EnqueuePartyUpsert(batch, siu);
+                            _si.EnqueuePartyUpsert(batch, siu, flags);
                             break;
 
                         case SystemUserRecord su:
-                            _su.EnqueuePartyUpsert(batch, su);
+                            _su.EnqueuePartyUpsert(batch, su, flags);
                             break;
 
                         case EnterpriseUserRecord eu:
-                            _eu.EnqueuePartyUpsert(batch, eu);
+                            _eu.EnqueuePartyUpsert(batch, eu, flags);
                             break;
 
                         default:
@@ -298,13 +302,14 @@ internal partial class PostgreSqlPartyPersistence
             /*strpsql*/"""
             SELECT *
             FROM register.upsert_party(
-                @uuid,
-                @id,
+                @flags,
+                @set_uuid, @uuid,
+                @set_id, @id,
                 @ext_urn,
                 @user_ids,
                 @set_username, @username,
                 @party_type,
-                @display_name,
+                @set_display_name, @display_name,
                 @person_id,
                 @org_id,
                 @created_at,
@@ -365,11 +370,11 @@ internal partial class PostgreSqlPartyPersistence
             protected virtual string GetQuery(T party)
                 => DEFAULT_QUERY;
 
-            protected virtual void ValidateFields(T party)
+            protected virtual void ValidateFields(T party, PersistenceFeatureFlag[] flags)
             {
                 var userIds = party.User.SelectFieldValue(static u => u.UserIds);
 
-                Debug.Assert(party.PartyUuid.HasValue);
+                Debug.Assert(flags.Contains(PersistenceFeatureFlag.CreatePartyId) || party.PartyUuid.HasValue);
                 Debug.Assert(party.ExternalUrn.IsSet);
                 Debug.Assert(party.User.IsUnset || (userIds.HasValue && !userIds.Value.IsDefaultOrEmpty));
                 Debug.Assert(party.PartyType.HasValue && party.PartyType.Value == type);
@@ -383,7 +388,7 @@ internal partial class PostgreSqlPartyPersistence
 
                 if (type is PartyRecordType.Person or PartyRecordType.Organization or PartyRecordType.SelfIdentifiedUser)
                 {
-                    Debug.Assert(party.PartyId.HasValue);
+                    Debug.Assert(flags.Contains(PersistenceFeatureFlag.CreatePartyId) || party.PartyId.HasValue);
                 }
                 else
                 {
@@ -391,7 +396,7 @@ internal partial class PostgreSqlPartyPersistence
                 }
             }
 
-            protected virtual void AddPartyParameters(NpgsqlParameterCollection parameters, T party)
+            protected virtual void AddPartyParameters(NpgsqlParameterCollection parameters, T party, PersistenceFeatureFlag[] flags)
             {
                 var userIds = party.User
                     .SelectFieldValue(static u => u.UserIds)
@@ -399,13 +404,14 @@ internal partial class PostgreSqlPartyPersistence
 
                 var username = party.User.SelectFieldValue(static u => u.Username);
 
-                parameters.Add<Guid>("uuid", NpgsqlDbType.Uuid).TypedValue = party.PartyUuid.Value;
-                parameters.Add<int?>("id", NpgsqlDbType.Bigint).TypedValue = party.PartyId.IsNull ? null : checked((int)party.PartyId.Value);
+                parameters.Add<PersistenceFeatureFlag[]>("flags").TypedValue = flags;
+                parameters.AddOptional("set_uuid", "uuid", NpgsqlDbType.Uuid, party.PartyUuid);
+                parameters.AddOptional("set_id", "id", NpgsqlDbType.Bigint, party.PartyId.Select(static id => checked((long)id)));
                 parameters.Add<string?>("ext_urn", NpgsqlDbType.Text).TypedValue = party.ExternalUrn.Value?.Urn;
                 parameters.Add<int[]?>("user_ids", NpgsqlDbType.Bigint | NpgsqlDbType.Array).TypedValue = userIds.OrDefault();
                 parameters.AddOptional("set_username", "username", NpgsqlDbType.Text, username);
                 parameters.Add<PartyRecordType>("party_type").TypedValue = party.PartyType.Value;
-                parameters.Add<string>("display_name", NpgsqlDbType.Text).TypedValue = party.DisplayName.Value;
+                parameters.AddOptional("set_display_name", "display_name", NpgsqlDbType.Text, party.DisplayName);
                 parameters.Add<string>("person_id", NpgsqlDbType.Text).TypedValue = party.PersonIdentifier.IsNull ? null : party.PersonIdentifier.Value!.ToString();
                 parameters.Add<string>("org_id", NpgsqlDbType.Text).TypedValue = party.OrganizationIdentifier.IsNull ? null : party.OrganizationIdentifier.Value!.ToString();
                 parameters.Add<DateTimeOffset>("created_at", NpgsqlDbType.TimestampTz).TypedValue = party.CreatedAt.Value.ToUniversalTime();
@@ -417,12 +423,12 @@ internal partial class PostgreSqlPartyPersistence
 
             public abstract Task<T> ReadResult(NpgsqlDataReader reader, CancellationToken cancellationToken);
 
-            public void EnqueuePartyUpsert(NpgsqlBatch batch, T party)
+            public void EnqueuePartyUpsert(NpgsqlBatch batch, T party, PersistenceFeatureFlag[] flags)
             {
-                ValidateFields(party);
+                ValidateFields(party, flags);
 
                 var cmd = batch.CreateBatchCommand(GetQuery(party));
-                AddPartyParameters(cmd.Parameters, party);
+                AddPartyParameters(cmd.Parameters, party, flags);
             }
         }
 
@@ -433,13 +439,14 @@ internal partial class PostgreSqlPartyPersistence
                 /*strpsql*/"""
                 SELECT *
                 FROM register.upsert_party_pers(
-                    @uuid,
-                    @id,
+                    @flags,
+                    @set_uuid, @uuid,
+                    @set_id, @id,
                     @ext_urn,
                     @user_ids,
                     @set_username, @username,
                     @party_type,
-                    @display_name,
+                    @set_display_name, @display_name,
                     @person_id,
                     @org_id,
                     @created_at,
@@ -447,23 +454,23 @@ internal partial class PostgreSqlPartyPersistence
                     @set_is_deleted, @is_deleted,
                     @set_deleted_at, @deleted_at,
                     @set_owner, @owner,
-                    @first_name,
-                    @middle_name,
-                    @last_name,
-                    @short_name,
-                    @date_of_birth,
-                    @date_of_death,
-                    @address,
-                    @mailing_address,
+                    @set_first_name, @first_name,
+                    @set_middle_name, @middle_name,
+                    @set_last_name, @last_name,
+                    @set_short_name, @short_name,
+                    @set_date_of_birth, @date_of_birth,
+                    @set_date_of_death, @date_of_death,
+                    @set_address, @address,
+                    @set_mailing_address, @mailing_address,
                     @set_source, @source)
                 """;
 
             protected override string GetQuery(PersonRecord party)
                 => QUERY;
 
-            protected override void ValidateFields(PersonRecord party)
+            protected override void ValidateFields(PersonRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.ValidateFields(party);
+                base.ValidateFields(party, flags);
                 Debug.Assert(!party.Source.IsNull, "person cannot have source = null");
                 Debug.Assert(party.FirstName.HasValue, "person must have FirstName set");
                 Debug.Assert(party.MiddleName.IsSet, "person must have MiddleName set");
@@ -476,17 +483,17 @@ internal partial class PostgreSqlPartyPersistence
                 Debug.Assert(!party.OwnerUuid.HasValue, "person cannot have OwnerUuid set");
             }
 
-            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, PersonRecord party)
+            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, PersonRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.AddPartyParameters(parameters, party);
-                parameters.Add<string>("first_name", NpgsqlDbType.Text).TypedValue = party.FirstName.Value;
-                parameters.Add<string?>("middle_name", NpgsqlDbType.Text).TypedValue = party.MiddleName.IsNull ? null : party.MiddleName.Value;
-                parameters.Add<string>("last_name", NpgsqlDbType.Text).TypedValue = party.LastName.Value;
-                parameters.Add<string>("short_name", NpgsqlDbType.Text).TypedValue = party.ShortName.Value;
-                parameters.Add<DateOnly>("date_of_birth").TypedValue = party.DateOfBirth.Value;
-                parameters.Add<DateOnly?>("date_of_death").TypedValue = party.DateOfDeath.IsNull ? null : party.DateOfDeath.Value;
-                parameters.Add<StreetAddressRecord>("address").TypedValue = party.Address.Value;
-                parameters.Add<MailingAddressRecord>("mailing_address").TypedValue = party.MailingAddress.Value;
+                base.AddPartyParameters(parameters, party, flags);
+                parameters.AddOptional("set_first_name", "first_name", NpgsqlDbType.Text, party.FirstName);
+                parameters.AddOptional("set_middle_name", "middle_name", NpgsqlDbType.Text, party.MiddleName);
+                parameters.AddOptional("set_last_name", "last_name", NpgsqlDbType.Text, party.LastName);
+                parameters.AddOptional("set_short_name", "short_name", NpgsqlDbType.Text, party.ShortName);
+                parameters.AddOptional("set_date_of_birth", "date_of_birth", party.DateOfBirth);
+                parameters.AddOptional("set_date_of_death", "date_of_death", party.DateOfDeath);
+                parameters.AddOptional("set_address", "address", party.Address);
+                parameters.AddOptional("set_mailing_address", "mailing_address", party.MailingAddress);
                 parameters.AddOptional("set_source", "source", party.Source);
             }
 
@@ -528,13 +535,14 @@ internal partial class PostgreSqlPartyPersistence
                 /*strpsql*/"""
                 SELECT *
                 FROM register.upsert_party_org(
-                    @uuid,
-                    @id,
+                    @flags,
+                    @set_uuid, @uuid,
+                    @set_id, @id,
                     @ext_urn,
                     @user_ids,
                     @set_username, @username,
                     @party_type,
-                    @display_name,
+                    @set_display_name, @display_name,
                     @person_id,
                     @org_id,
                     @created_at,
@@ -542,24 +550,24 @@ internal partial class PostgreSqlPartyPersistence
                     @set_is_deleted, @is_deleted,
                     @set_deleted_at, @deleted_at,
                     @set_owner, @owner,
-                    @unit_status,
-                    @unit_type,
-                    @telephone_number,
-                    @mobile_number,
-                    @fax_number,
-                    @email_address,
-                    @internet_address,
-                    @mailing_address,
-                    @business_address,
+                    @set_unit_status, @unit_status,
+                    @set_unit_type, @unit_type,
+                    @set_telephone_number, @telephone_number,
+                    @set_mobile_number, @mobile_number,
+                    @set_fax_number, @fax_number,
+                    @set_email_address, @email_address,
+                    @set_internet_address, @internet_address,
+                    @set_mailing_address, @mailing_address,
+                    @set_business_address, @business_address,
                     @set_source, @source)
                 """;
 
             protected override string GetQuery(OrganizationRecord party)
                 => QUERY;
 
-            protected override void ValidateFields(OrganizationRecord party)
+            protected override void ValidateFields(OrganizationRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.ValidateFields(party);
+                base.ValidateFields(party, flags);
                 Debug.Assert(party.UnitStatus.HasValue);
                 Debug.Assert(party.UnitType.HasValue);
                 Debug.Assert(party.TelephoneNumber.IsSet);
@@ -572,18 +580,18 @@ internal partial class PostgreSqlPartyPersistence
                 Debug.Assert(!party.OwnerUuid.HasValue, "organization cannot have OwnerUuid set");
             }
 
-            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, OrganizationRecord party)
+            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, OrganizationRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.AddPartyParameters(parameters, party);
-                parameters.Add<string>("unit_status", NpgsqlDbType.Text).TypedValue = party.UnitStatus.Value;
-                parameters.Add<string>("unit_type", NpgsqlDbType.Text).TypedValue = party.UnitType.Value;
-                parameters.Add<string>("telephone_number", NpgsqlDbType.Text).TypedValue = party.TelephoneNumber.Value;
-                parameters.Add<string>("mobile_number", NpgsqlDbType.Text).TypedValue = party.MobileNumber.Value;
-                parameters.Add<string>("fax_number", NpgsqlDbType.Text).TypedValue = party.FaxNumber.Value;
-                parameters.Add<string>("email_address", NpgsqlDbType.Text).TypedValue = party.EmailAddress.Value;
-                parameters.Add<string>("internet_address", NpgsqlDbType.Text).TypedValue = party.InternetAddress.Value;
-                parameters.Add<MailingAddressRecord>("mailing_address").TypedValue = party.MailingAddress.Value;
-                parameters.Add<MailingAddressRecord>("business_address").TypedValue = party.BusinessAddress.Value;
+                base.AddPartyParameters(parameters, party, flags);
+                parameters.AddOptional("set_unit_status", "unit_status", NpgsqlDbType.Text, party.UnitStatus);
+                parameters.AddOptional("set_unit_type", "unit_type", NpgsqlDbType.Text, party.UnitType);
+                parameters.AddOptional("set_telephone_number", "telephone_number", NpgsqlDbType.Text, party.TelephoneNumber);
+                parameters.AddOptional("set_mobile_number", "mobile_number", NpgsqlDbType.Text, party.MobileNumber);
+                parameters.AddOptional("set_fax_number", "fax_number", NpgsqlDbType.Text, party.FaxNumber);
+                parameters.AddOptional("set_email_address", "email_address", NpgsqlDbType.Text, party.EmailAddress);
+                parameters.AddOptional("set_internet_address", "internet_address", NpgsqlDbType.Text, party.InternetAddress);
+                parameters.AddOptional("set_mailing_address", "mailing_address", party.MailingAddress);
+                parameters.AddOptional("set_business_address", "business_address", party.BusinessAddress);
                 parameters.AddOptional("set_source", "source", party.Source);
             }
 
@@ -628,13 +636,14 @@ internal partial class PostgreSqlPartyPersistence
                 /*strpsql*/"""
                 SELECT *
                 FROM register.upsert_self_identified_user(
-                    @uuid,
-                    @id,
+                    @flags,
+                    @set_uuid, @uuid,
+                    @set_id, @id,
                     @ext_urn,
                     @user_ids,
                     @set_username, @username,
                     @party_type,
-                    @display_name,
+                    @set_display_name, @display_name,
                     @person_id,
                     @org_id,
                     @created_at,
@@ -657,9 +666,9 @@ internal partial class PostgreSqlPartyPersistence
                 return base.GetQuery(party);
             }
 
-            protected override void ValidateFields(SelfIdentifiedUserRecord party)
+            protected override void ValidateFields(SelfIdentifiedUserRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.ValidateFields(party);
+                base.ValidateFields(party, flags);
                 Debug.Assert(party.SelfIdentifiedUserType.IsSet);
 
                 if (party.SelfIdentifiedUserType.HasValue)
@@ -691,9 +700,9 @@ internal partial class PostgreSqlPartyPersistence
                 }
             }
 
-            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, SelfIdentifiedUserRecord party)
+            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, SelfIdentifiedUserRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.AddPartyParameters(parameters, party);
+                base.AddPartyParameters(parameters, party, flags);
 
                 if (party.SelfIdentifiedUserType.HasValue)
                 {
@@ -747,13 +756,14 @@ internal partial class PostgreSqlPartyPersistence
                 /*strpsql*/"""
                 SELECT *
                 FROM register.upsert_system_user(
-                    @uuid,
-                    @id,
+                    @flags,
+                    @set_uuid, @uuid,
+                    @set_id, @id,
                     @ext_urn,
                     @user_ids,
                     @set_username, @username,
                     @party_type,
-                    @display_name,
+                    @set_display_name, @display_name,
                     @person_id,
                     @org_id,
                     @created_at,
@@ -767,16 +777,16 @@ internal partial class PostgreSqlPartyPersistence
             protected override string GetQuery(SystemUserRecord party)
                 => QUERY;
 
-            protected override void ValidateFields(SystemUserRecord party)
+            protected override void ValidateFields(SystemUserRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.ValidateFields(party);
+                base.ValidateFields(party, flags);
 
                 Debug.Assert(party.SystemUserType.HasValue, "system user must have SystemUserType set");
             }
 
-            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, SystemUserRecord party)
+            protected override void AddPartyParameters(NpgsqlParameterCollection parameters, SystemUserRecord party, PersistenceFeatureFlag[] flags)
             {
-                base.AddPartyParameters(parameters, party);
+                base.AddPartyParameters(parameters, party, flags);
 
                 parameters.Add<SystemUserRecordType>("system_user_type").TypedValue = party.SystemUserType.Value;
             }

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.cs
@@ -12,6 +12,7 @@ using Altinn.Register.Core.Utils;
 using Altinn.Register.Persistence.AsyncEnumerables;
 using Altinn.Register.Persistence.DbArgTypes;
 using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
@@ -27,6 +28,7 @@ internal partial class PostgreSqlPartyPersistence
 {
     private readonly IUnitOfWorkHandle _handle;
     private readonly NpgsqlConnection _connection;
+    private readonly PersistenceFeatureFlag[] _flags;
     private readonly ILogger<PostgreSqlPartyPersistence> _logger;
 
     /// <summary>
@@ -35,11 +37,46 @@ internal partial class PostgreSqlPartyPersistence
     public PostgreSqlPartyPersistence(
         IUnitOfWorkHandle handle,
         NpgsqlConnection connection,
+        IConfiguration configuration,
         ILogger<PostgreSqlPartyPersistence> logger)
     {
         _handle = handle;
         _connection = connection;
         _logger = logger;
+
+        _flags = CreateFlags([
+            KeyValuePair.Create(PersistenceFeatureFlag.CreatePartyId, configuration.GetValue("Altinn:register:Party:CreatePartyId", defaultValue: false)),
+        ]);
+
+        static PersistenceFeatureFlag[] CreateFlags(params ReadOnlySpan<KeyValuePair<PersistenceFeatureFlag, bool>> flags)
+        {
+            var enabledCount = 0;
+            foreach (var kvp in flags)
+            {
+                if (kvp.Value)
+                {
+                    enabledCount++;
+                }
+            }
+
+            if (enabledCount == 0)
+            {
+                return [];
+            }
+
+            var result = new PersistenceFeatureFlag[enabledCount];
+            var index = 0;
+
+            foreach (var kvp in flags)
+            {
+                if (kvp.Value)
+                {
+                    result[index++] = kvp.Key;
+                }
+            }
+
+            return result;
+        }
     }
 
     #region Party
@@ -412,7 +449,7 @@ internal partial class PostgreSqlPartyPersistence
     {
         _handle.ThrowIfCompleted();
 
-        return UpsertPartyQuery.UpsertParty(_connection, party, cancellationToken).AsTask();
+        return UpsertPartyQuery.UpsertParty(_connection, party, _flags, cancellationToken).AsTask();
     }
 
     /// <inheritdoc/>
@@ -422,7 +459,7 @@ internal partial class PostgreSqlPartyPersistence
     {
         _handle.ThrowIfCompleted();
 
-        return UpsertPartyQuery.UpsertParties(_connection, parties, cancellationToken);
+        return UpsertPartyQuery.UpsertParties(_connection, parties, _flags, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/DataSourceMappingsTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/DataSourceMappingsTests.cs
@@ -182,6 +182,27 @@ public class DataSourceMappingsTests
     }
 
     [Theory]
+    [EnumMembersData<PersistenceFeatureFlag>]
+    public async Task MapDbFeatureFlag(PersistenceFeatureFlag flag)
+    {
+        var source = GetRequiredService<NpgsqlDataSource>();
+        await using var conn = await source.OpenConnectionAsync(CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = /*strpsql*/"SELECT @p::register.db_feature_flag";
+
+        var param = cmd.Parameters.Add<PersistenceFeatureFlag>("p");
+        param.TypedValue = flag;
+
+        await cmd.PrepareAsync(CancellationToken);
+
+        await using var reader = await cmd.ExecuteReaderAsync(CancellationToken);
+        (await reader.ReadAsync(CancellationToken)).ShouldBeTrue();
+
+        var result = await reader.GetFieldValueAsync<PersistenceFeatureFlag>(0, CancellationToken);
+        result.ShouldBe(flag);
+    }
+
+    [Theory]
     [MemberData(nameof(MailingAddresses))]
     public async Task MapsMailingAddress(SerializableMailingAddress? address)
     {

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
@@ -698,6 +698,49 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task UpsertParty_Org_NoPartyIds_Inserts_New_Org()
+    {
+        var orgNo = await UoW.GetNewOrgNumber(CancellationToken);
+
+        var toInsert = new OrganizationRecord
+        {
+            PartyUuid = FieldValue.Unset,
+            PartyId = FieldValue.Unset,
+            ExternalUrn = PartyExternalRefUrn.OrganizationId.Create(orgNo),
+            DisplayName = "Test",
+            PersonIdentifier = null,
+            OrganizationIdentifier = orgNo,
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            IsDeleted = false,
+            DeletedAt = FieldValue.Null,
+            User = FieldValue.Unset,
+            VersionId = FieldValue.Unset,
+            OwnerUuid = FieldValue.Null,
+            Source = orgNo.ToString().StartsWith('0') ? OrganizationSource.BusinessAssessedPartnerships : OrganizationSource.CentralCoordinatingRegister,
+            UnitStatus = "N",
+            UnitType = "AS",
+            TelephoneNumber = null,
+            MobileNumber = null,
+            FaxNumber = null,
+            EmailAddress = null,
+            InternetAddress = null,
+            MailingAddress = null,
+            BusinessAddress = null,
+        };
+
+        var result = await Persistence.UpsertParty(toInsert, cancellationToken: CancellationToken);
+        var inserted = result.ShouldHaveValue().ShouldBeOfType<OrganizationRecord>();
+        inserted.PartyUuid.ShouldHaveValue();
+        inserted.PartyId.ShouldHaveValue();
+        inserted.PartyId.Value.ShouldBeGreaterThan(1_000_000_000U);
+        inserted.ShouldBeEquivalentTo(toInsert with { PartyId = inserted.PartyId, PartyUuid = inserted.PartyUuid, VersionId = inserted.VersionId });
+
+        var fromDb = await Persistence.GetPartyById(inserted.PartyUuid.Value, PartyFieldIncludes.Party | PartyFieldIncludes.Organization, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
+        fromDb.ShouldBeEquivalentTo(toInsert with { PartyId = inserted.PartyId, PartyUuid = inserted.PartyUuid, VersionId = fromDb.VersionId });
+    }
+
+    [Fact]
     public async Task UpsertParty_Org_Updates_Name_And_Updated_And_OrgProps()
     {
         var id = await UoW.GetNextPartyId(CancellationToken);
@@ -765,6 +808,78 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
 
         var fromDb = await Persistence.GetPartyById(uuid, PartyFieldIncludes.Party | PartyFieldIncludes.Organization, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
         fromDb.ShouldBeEquivalentTo(expected with { VersionId = fromDb.VersionId });
+    }
+
+    [Fact]
+    public async Task UpsertParty_Org_NoPartyIds_Updates_Name_And_Updated_And_OrgProps()
+    {
+        var orgNo = await UoW.GetNewOrgNumber(CancellationToken);
+
+        var toInsert = new OrganizationRecord
+        {
+            PartyUuid = FieldValue.Unset,
+            PartyId = FieldValue.Unset,
+            ExternalUrn = PartyExternalRefUrn.OrganizationId.Create(orgNo),
+            DisplayName = "Test",
+            PersonIdentifier = null,
+            OrganizationIdentifier = orgNo,
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            IsDeleted = false,
+            DeletedAt = FieldValue.Null,
+            User = FieldValue.Unset,
+            VersionId = FieldValue.Unset,
+            OwnerUuid = FieldValue.Null,
+            Source = orgNo.ToString().StartsWith('0') ? OrganizationSource.BusinessAssessedPartnerships : OrganizationSource.CentralCoordinatingRegister,
+            UnitStatus = "N",
+            UnitType = "AS",
+            TelephoneNumber = null,
+            MobileNumber = null,
+            FaxNumber = null,
+            EmailAddress = null,
+            InternetAddress = null,
+            MailingAddress = null,
+            BusinessAddress = null,
+        };
+
+        var result = await Persistence.UpsertParty(toInsert, cancellationToken: CancellationToken);
+        result.ShouldHaveValue();
+        var inserted = result.Value!;
+        inserted.PartyUuid.ShouldHaveValue();
+        inserted.PartyId.ShouldHaveValue();
+        inserted.PartyId.Value.ShouldBeGreaterThan(1_000_000_000U);
+
+        TimeProvider.Advance(TimeSpan.FromDays(30));
+
+        var toUpdate = toInsert with
+        {
+            DisplayName = "Test Updated",
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            UnitStatus = "U",
+            UnitType = "hovedenhet",
+            TelephoneNumber = "tel",
+            MobileNumber = "mob",
+            FaxNumber = "fax",
+            EmailAddress = "email",
+            InternetAddress = "internet",
+            MailingAddress = new MailingAddressRecord { Address = "mailing", City = "mailing city", PostalCode = "0123" },
+            BusinessAddress = new MailingAddressRecord { Address = "business", City = "business city", PostalCode = "0123" },
+        };
+
+        result = await Persistence.UpsertParty(toUpdate, cancellationToken: CancellationToken);
+        result.ShouldHaveValue();
+
+        var expected = toUpdate with
+        {
+            CreatedAt = toInsert.CreatedAt, // created at should not change
+        };
+
+        var updated = result.Value.ShouldBeOfType<OrganizationRecord>();
+        updated.ShouldBeEquivalentTo(expected with { PartyId = inserted.PartyId, PartyUuid = inserted.PartyUuid, VersionId = updated.VersionId });
+
+        var fromDb = await Persistence.GetPartyById(inserted.PartyUuid.Value, PartyFieldIncludes.Party | PartyFieldIncludes.Organization, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
+        fromDb.ShouldBeEquivalentTo(expected with { PartyId = inserted.PartyId, PartyUuid = inserted.PartyUuid, VersionId = fromDb.VersionId });
     }
 
     [Fact]
@@ -998,6 +1113,63 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task UpsertParty_Person_NoPartyIds_Inserts_New_Person()
+    {
+        var birthDate = UoW.GetRandomBirthDate();
+        var isDNumber = TestDataGenerator.GetRandomBool(0.1); // 10% chance of D-number
+        var personId = await UoW.GetNewPersonIdentifier(birthDate, isDNumber, CancellationToken);
+
+        var toInsert = new PersonRecord
+        {
+            PartyUuid = FieldValue.Unset,
+            PartyId = FieldValue.Unset,
+            ExternalUrn = PartyExternalRefUrn.PersonId.Create(personId),
+            DisplayName = "Test Mid Testson",
+            PersonIdentifier = personId,
+            OrganizationIdentifier = null,
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            IsDeleted = false,
+            DeletedAt = FieldValue.Null,
+            User = FieldValue.Unset,
+            VersionId = FieldValue.Unset,
+            OwnerUuid = FieldValue.Null,
+            Source = PersonSource.NationalPopulationRegister,
+            FirstName = "Test",
+            MiddleName = "Mid",
+            LastName = "Testson",
+            ShortName = "TESTSON Test Mid",
+            Address = null,
+            MailingAddress = null,
+            DateOfBirth = birthDate,
+            DateOfDeath = FieldValue.Null,
+        };
+
+        var result = await Persistence.UpsertParty(toInsert, cancellationToken: CancellationToken);
+        var inserted = result.ShouldHaveValue().ShouldBeOfType<PersonRecord>();
+        inserted.PartyUuid.ShouldHaveValue();
+        inserted.PartyId.ShouldHaveValue();
+        inserted.PartyId.Value.ShouldBeGreaterThan(1_000_000_000U);
+        inserted.User.ShouldHaveValue().UserId.ShouldHaveValue().ShouldBe(inserted.PartyId.Value);
+        inserted.ShouldBeEquivalentTo(toInsert with
+        {
+            PartyId = inserted.PartyId,
+            PartyUuid = inserted.PartyUuid,
+            User = new PartyUserRecord(inserted.PartyId.Value, FieldValue.Null),
+            VersionId = inserted.VersionId,
+        });
+
+        var fromDb = await Persistence.GetPartyById(inserted.PartyUuid.Value, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.User, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
+        fromDb.ShouldBeEquivalentTo(toInsert with
+        {
+            PartyId = inserted.PartyId,
+            PartyUuid = inserted.PartyUuid,
+            User = new PartyUserRecord(inserted.PartyId.Value, FieldValue.Null),
+            VersionId = inserted.VersionId,
+        });
+    }
+
+    [Fact]
     public async Task UpsertParty_Person_Updates_Name_And_Updated_And_PersonProps()
     {
         var id = await UoW.GetNextPartyId(CancellationToken);
@@ -1074,6 +1246,99 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
 
         var fromDb = await Persistence.GetPartyById(uuid, PartyFieldIncludes.Party | PartyFieldIncludes.Person, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
         fromDb.ShouldBeEquivalentTo(expected with { VersionId = fromDb.VersionId });
+    }
+
+    [Fact]
+    public async Task UpsertParty_Person_NoPartyIds_Updates_Name_And_Updated_And_PersonProps()
+    {
+        var birthDate = UoW.GetRandomBirthDate();
+        var isDNumber = TestDataGenerator.GetRandomBool(0.1); // 10% chance of D-number
+        var personId = await UoW.GetNewPersonIdentifier(birthDate, isDNumber, CancellationToken);
+
+        var toInsert = new PersonRecord
+        {
+            PartyUuid = FieldValue.Unset,
+            PartyId = FieldValue.Unset,
+            ExternalUrn = PartyExternalRefUrn.PersonId.Create(personId),
+            DisplayName = "Test Mid Testson",
+            PersonIdentifier = personId,
+            OrganizationIdentifier = null,
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            IsDeleted = false,
+            DeletedAt = FieldValue.Null,
+            User = FieldValue.Unset,
+            VersionId = FieldValue.Unset,
+            OwnerUuid = FieldValue.Null,
+            Source = PersonSource.NationalPopulationRegister,
+            FirstName = "Test",
+            MiddleName = "Mid",
+            LastName = "Testson",
+            ShortName = "TESTSON Test Mid",
+            Address = null,
+            MailingAddress = null,
+            DateOfBirth = birthDate,
+            DateOfDeath = FieldValue.Null,
+        };
+
+        var result = await Persistence.UpsertParty(toInsert, cancellationToken: CancellationToken);
+        result.ShouldHaveValue();
+        var inserted = result.Value!;
+        inserted.PartyUuid.ShouldHaveValue();
+        inserted.PartyId.ShouldHaveValue();
+        inserted.PartyId.Value.ShouldBeGreaterThan(1_000_000_000U);
+
+        TimeProvider.Advance(TimeSpan.FromDays(30));
+
+        var toUpdate = toInsert with
+        {
+            DisplayName = "Test Updated",
+            CreatedAt = TimeProvider.GetUtcNow(),
+            ModifiedAt = TimeProvider.GetUtcNow(),
+            FirstName = "Test Updated",
+            MiddleName = "Mid Updated",
+            LastName = "Testson Updated",
+            ShortName = "TESTSON Updated Test Mid",
+            Address = new StreetAddressRecord
+            {
+                MunicipalName = "mn",
+                MunicipalNumber = "00",
+                HouseNumber = "50",
+                HouseLetter = "L",
+                City = "s",
+                PostalCode = "pc",
+                StreetName = "sn",
+            },
+            MailingAddress = new MailingAddressRecord { Address = "mailing", City = "mailing city", PostalCode = "mailing postal code" },
+            DateOfBirth = birthDate.AddDays(10),
+            DateOfDeath = birthDate.AddDays(30),
+        };
+
+        result = await Persistence.UpsertParty(toUpdate, cancellationToken: CancellationToken);
+        result.ShouldHaveValue();
+
+        var expected = toUpdate with
+        {
+            CreatedAt = toInsert.CreatedAt, // created at should not change
+        };
+
+        var updated = result.Value.ShouldBeOfType<PersonRecord>();
+        updated.ShouldBeEquivalentTo(expected with
+        {
+            PartyId = inserted.PartyId,
+            PartyUuid = inserted.PartyUuid,
+            User = FieldValue.Unset, // user-id is not returned unless updated explicitly
+            VersionId = updated.VersionId,
+        });
+
+        var fromDb = await Persistence.GetPartyById(inserted.PartyUuid.Value, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.User, cancellationToken: CancellationToken).SingleAsync(CancellationToken);
+        fromDb.ShouldBeEquivalentTo(expected with
+        {
+            PartyId = inserted.PartyId,
+            PartyUuid = inserted.PartyUuid,
+            User = new PartyUserRecord(inserted.PartyId.Value, FieldValue.Null),
+            VersionId = updated.VersionId,
+        });
     }
 
     [Fact]

--- a/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/DatabaseTestBase.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/DatabaseTestBase.cs
@@ -31,6 +31,12 @@ public abstract class DatabaseTestBase
     /// </summary>
     protected RegisterTestDataGenerator TestDataGenerator => GetRequiredService<RegisterTestDataGenerator>();
 
+    /// <summary>
+    /// Gets the application configuration.
+    /// </summary>
+    protected IConfigurationManager Configuration
+        => (IConfigurationManager)GetRequiredService<IConfiguration>();
+
     /// <inheritdoc/>
     protected override async ValueTask ConfigureHost(IHostApplicationBuilder builder)
     {
@@ -49,6 +55,9 @@ public abstract class DatabaseTestBase
             new("Altinn:Npgsql:register:Migrate:ConnectionString", _db.MigratorConnectionString),
             new("Altinn:Npgsql:register:Seed:ConnectionString", _db.SeederConnectionString),
             new("Altinn:Npgsql:register:Seed:Enabled", SeedData ? "true" : "false"),
+
+            // feature flags
+            new("Altinn:register:Party:CreatePartyId", "true"),
         ]);
 
         builder.AddRegisterPersistence();

--- a/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/TestData/RegisterTestDataGenerator.UsedIdentifiers.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/TestData/RegisterTestDataGenerator.UsedIdentifiers.cs
@@ -48,6 +48,7 @@ public sealed partial class RegisterTestDataGenerator
                 /*strpsql*/"""
                 SELECT MAX(id)
                 FROM register.party
+                WHERE id < 1000000000
                 """,
                 cancellationToken);
 
@@ -56,6 +57,7 @@ public sealed partial class RegisterTestDataGenerator
                 /*strpsql*/"""
                 SELECT MAX(user_id)
                 FROM register."user"
+                WHERE user_id < 1000000000
                 """,
                 cancellationToken);
 


### PR DESCRIPTION
# Database Diffs:

## v0.47-si-types/02-upsert-party.sql -> 03-upsert-party.sql

```diff
--- src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.47-si-types/02-upsert-party.sql	2026-04-07 17:26:31.695543410 +0200
+++ src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/03-upsert-party.sql	2026-05-07 17:54:27.022247249 +0200
@@ -1,12 +1,15 @@
-
 CREATE OR REPLACE FUNCTION register.upsert_party(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
   INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
   INOUT p_id register.party.id%TYPE,
   INOUT p_ext_urn register.party.ext_urn%TYPE,
-  INOUT p_user_ids bigint[],
+  INOUT p_user_ids bigint[], -- The user_ids is considered unset if it is NULL
   IN s_username boolean,
   INOUT p_username text,
   INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
   INOUT p_display_name register.party.display_name%TYPE,
   INOUT p_person_identifier register.party.person_identifier%TYPE,
   INOUT p_organization_identifier register.party.organization_identifier%TYPE,
@@ -24,15 +27,51 @@
 DECLARE
   o_party register.party%ROWTYPE;
 BEGIN
+  -- Validate some parameters
+  IF s_uuid <> s_id THEN
+    RAISE EXCEPTION 'Parameters "s_uuid" and "s_id" must be the same. Either both are known or none of them are.'
+      USING ERRCODE = 'ZZ003'
+          , SCHEMA = 'register'
+          , TABLE = 'party';
+  END IF;
+
+  IF NOT s_uuid AND p_user_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'Parameter "p_user_ids" cannot be set without "s_uuid"'
+      USING ERRCODE = 'ZZ003'
+          , SCHEMA = 'register'
+          , TABLE = 'party';
+  END IF;
+
   -- Get existing party by UUID if it exists
   SELECT p.*
   INTO o_party
   FROM register.party p
-  WHERE p.uuid = p_uuid
+  WHERE (s_uuid AND p.uuid = p_uuid)
+     OR (NOT s_uuid AND p_person_identifier IS NOT NULL AND p.person_identifier = p_person_identifier)
+     OR (NOT s_uuid AND p_organization_identifier IS NOT NULL AND p.organization_identifier = p_organization_identifier)
+  LIMIT 1
   FOR NO KEY UPDATE;
 
   -- If the party does not exist, insert it and return it
   IF NOT FOUND THEN
+    -- If the uuid/id is not provided, find the existing party by alternate keys (person_identifier or organization_identifier), or generate new ones
+    IF NOT s_uuid THEN
+      -- We've already attempted to find the party by alternate keys, so this means it's a new party that doesn't have a uuid/id yet.
+      IF NOT 'create_party_id' = ANY(p_flags) THEN
+        RAISE EXCEPTION 'Creating new party-ids is not allowed without "create_party_id" feature flag'
+          USING ERRCODE = 'ZZ004'
+              , SCHEMA = 'register'
+              , TABLE = 'party';
+      END IF;
+
+      p_uuid := gen_random_uuid();
+      p_id := nextval('register.party_inc_id_sec');
+
+      IF p_party_type IN('person', 'self-identified-user') THEN
+        p_user_ids := ARRAY[p_id];
+      END IF;
+    END IF;
+
     -- Assign defaults to optional fields
     IF NOT s_is_deleted THEN
       p_is_deleted := FALSE;
@@ -47,6 +86,13 @@
     END IF;
 
     -- Validate required fields
+    IF NOT s_display_name THEN
+      RAISE EXCEPTION 'null value in column "display_name" of relation "party" violates not-null constraint'
+        USING ERRCODE = '23502'
+            , SCHEMA = 'register'
+            , TABLE = 'party'
+            , COLUMN = 'display_name';
+    END IF;
 
     -- Insert new party
     INSERT INTO register.party (uuid, id, party_type, ext_urn, display_name, person_identifier, organization_identifier, created, updated, is_deleted, deleted_at, "owner")
@@ -55,7 +101,7 @@
 
   ELSE
     -- Validate that the updated party does not modify any immutable fields
-    IF o_party.id <> p_id THEN
+    IF s_id AND o_party.id <> p_id THEN
       RAISE EXCEPTION 'Cannot update immutable field "id" on party, existing: %, updated: %, party_uuid: %', o_party.id, p_id, p_uuid
         USING ERRCODE = 'ZZ001'
             , SCHEMA = 'register'
@@ -97,8 +143,12 @@
       END IF;
     END IF;
 
+    -- Set expected fields based on lookup now allowing alternate keys
+    p_uuid := o_party.uuid;
+    p_id := o_party.id;
+
     UPDATE register.party p
-    SET display_name = p_display_name
+    SET display_name = CASE WHEN s_display_name THEN p_display_name ELSE p.display_name END
       , updated = p_updated
       , is_deleted = CASE WHEN s_is_deleted THEN p_is_deleted ELSE p.is_deleted END
       , deleted_at = CASE WHEN s_deleted_at THEN p_deleted_at ELSE p.deleted_at END
```

## v0.49-party-sources/03-upsert-org.sql -> 04-upsert-org.sql

```diff
--- src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.49-party-sources/03-upsert-org.sql	2026-04-07 17:26:31.695543410 +0200
+++ src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/04-upsert-org.sql	2026-05-07 17:54:27.022247249 +0200
@@ -1,11 +1,15 @@
 CREATE OR REPLACE FUNCTION register.upsert_party_org(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
   INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
   INOUT p_id register.party.id%TYPE,
   INOUT p_ext_urn register.party.ext_urn%TYPE,
   INOUT p_user_ids bigint[],
   IN s_username boolean,
   INOUT p_username text,
   INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
   INOUT p_display_name register.party.display_name%TYPE,
   INOUT p_person_identifier register.party.person_identifier%TYPE,
   INOUT p_organization_identifier register.party.organization_identifier%TYPE,
@@ -17,14 +21,23 @@
   INOUT p_deleted_at register.party.deleted_at%TYPE,
   IN s_owner boolean,
   INOUT p_owner register.party.owner%TYPE,
+  IN s_unit_status boolean,
   INOUT p_unit_status register.organization.unit_status%TYPE,
+  IN s_unit_type boolean,
   INOUT p_unit_type register.organization.unit_type%TYPE,
+  IN s_telephone_number boolean,
   INOUT p_telephone_number register.organization.telephone_number%TYPE,
+  IN s_mobile_number boolean,
   INOUT p_mobile_number register.organization.mobile_number%TYPE,
+  IN s_fax_number boolean,
   INOUT p_fax_number register.organization.fax_number%TYPE,
+  IN s_email_address boolean,
   INOUT p_email_address register.organization.email_address%TYPE,
+  IN s_internet_address boolean,
   INOUT p_internet_address register.organization.internet_address%TYPE,
+  IN s_mailing_address boolean,
   INOUT p_mailing_address register.organization.mailing_address%TYPE,
+  IN s_business_address boolean,
   INOUT p_business_address register.organization.business_address%TYPE,
   IN s_source boolean,
   INOUT p_source register.organization.source%TYPE,
@@ -39,12 +52,16 @@
   -- Upsert the party
   SELECT *
   FROM register.upsert_party(
+    p_flags,
+    s_uuid,
     p_uuid,
+    s_id,
     p_id,
     p_ext_urn,
     p_user_ids,
     s_username, p_username,
     p_party_type,
+    s_display_name,
     p_display_name,
     p_person_identifier,
     p_organization_identifier,
@@ -79,7 +96,44 @@
 
   -- If the organization does not exist, insert it and return it
   IF NOT FOUND THEN
-    -- Check required (for insertion) parameters are set
+    -- Assign defaults to optional fields
+    IF NOT s_unit_status THEN
+      p_unit_status := NULL;
+    END IF;
+
+    IF NOT s_unit_type THEN
+      p_unit_type := NULL;
+    END IF;
+
+    IF NOT s_telephone_number THEN
+      p_telephone_number := NULL;
+    END IF;
+
+    IF NOT s_mobile_number THEN
+      p_mobile_number := NULL;
+    END IF;
+
+    IF NOT s_fax_number THEN
+      p_fax_number := NULL;
+    END IF;
+
+    IF NOT s_email_address THEN
+      p_email_address := NULL;
+    END IF;
+
+    IF NOT s_internet_address THEN
+      p_internet_address := NULL;
+    END IF;
+
+    IF NOT s_mailing_address THEN
+      p_mailing_address := NULL;
+    END IF;
+
+    IF NOT s_business_address THEN
+      p_business_address := NULL;
+    END IF;
+
+    -- Validate required fields
     IF NOT s_source THEN
       RAISE EXCEPTION 'null value in column "source" of relation "organization" violates not-null constraint'
         USING ERRCODE = '23502'
@@ -95,15 +149,15 @@
   ELSE
     -- Update the organization
     UPDATE register.organization o
-    SET unit_status = p_unit_status
-      , unit_type = p_unit_type
-      , telephone_number = p_telephone_number
-      , mobile_number = p_mobile_number
-      , fax_number = p_fax_number
-      , email_address = p_email_address
-      , internet_address = p_internet_address
-      , mailing_address = p_mailing_address
-      , business_address = p_business_address
+    SET unit_status = CASE WHEN s_unit_status THEN p_unit_status ELSE o.unit_status END
+      , unit_type = CASE WHEN s_unit_type THEN p_unit_type ELSE o.unit_type END
+      , telephone_number = CASE WHEN s_telephone_number THEN p_telephone_number ELSE o.telephone_number END
+      , mobile_number = CASE WHEN s_mobile_number THEN p_mobile_number ELSE o.mobile_number END
+      , fax_number = CASE WHEN s_fax_number THEN p_fax_number ELSE o.fax_number END
+      , email_address = CASE WHEN s_email_address THEN p_email_address ELSE o.email_address END
+      , internet_address = CASE WHEN s_internet_address THEN p_internet_address ELSE o.internet_address END
+      , mailing_address = CASE WHEN s_mailing_address THEN p_mailing_address ELSE o.mailing_address END
+      , business_address = CASE WHEN s_business_address THEN p_business_address ELSE o.business_address END
       , source = CASE
           WHEN s_source THEN p_source
           ELSE o.source
```

## v0.49-party-sources/04-upsert-pers.sql -> 05-upsert-pers.sql

```diff
--- src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.49-party-sources/04-upsert-pers.sql	2026-04-07 17:26:31.695543410 +0200
+++ src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/05-upsert-pers.sql	2026-05-07 17:54:27.022247249 +0200
@@ -1,11 +1,15 @@
 CREATE OR REPLACE FUNCTION register.upsert_party_pers(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
   INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
   INOUT p_id register.party.id%TYPE,
   INOUT p_ext_urn register.party.ext_urn%TYPE,
   INOUT p_user_ids bigint[],
   IN s_username boolean,
   INOUT p_username text,
   INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
   INOUT p_display_name register.party.display_name%TYPE,
   INOUT p_person_identifier register.party.person_identifier%TYPE,
   INOUT p_organization_identifier register.party.organization_identifier%TYPE,
@@ -17,13 +21,21 @@
   INOUT p_deleted_at register.party.deleted_at%TYPE,
   IN s_owner boolean,
   INOUT p_owner register.party.owner%TYPE,
+  IN s_first_name boolean,
   INOUT p_first_name register.person.first_name%TYPE,
+  IN s_middle_name boolean,
   INOUT p_middle_name register.person.middle_name%TYPE,
+  IN s_last_name boolean,
   INOUT p_last_name register.person.last_name%TYPE,
+  IN s_short_name boolean,
   INOUT p_short_name register.person.short_name%TYPE,
+  IN s_date_of_birth boolean,
   INOUT p_date_of_birth register.person.date_of_birth%TYPE,
+  IN s_date_of_death boolean,
   INOUT p_date_of_death register.person.date_of_death%TYPE,
+  IN s_address boolean,
   INOUT p_address register.person.address%TYPE,
+  IN s_mailing_address boolean,
   INOUT p_mailing_address register.person.mailing_address%TYPE,
   IN s_source boolean,
   INOUT p_source register.person.source%TYPE,
@@ -38,12 +50,16 @@
   -- Upsert the party
   SELECT *
   FROM register.upsert_party(
+    p_flags,
+    s_uuid,
     p_uuid,
+    s_id,
     p_id,
     p_ext_urn,
     p_user_ids,
     s_username, p_username,
     p_party_type,
+    s_display_name,
     p_display_name,
     p_person_identifier,
     p_organization_identifier,
@@ -78,9 +94,42 @@
 
   -- If the person does not exist, insert it and return it
   IF NOT FOUND THEN
-    -- Check required (for insertion) parameters are set
+    -- Assign defaults to optional fields
+    IF NOT s_first_name THEN
+      p_first_name := NULL;
+    END IF;
+
+    IF NOT s_middle_name THEN
+      p_middle_name := NULL;
+    END IF;
+
+    IF NOT s_last_name THEN
+      p_last_name := NULL;
+    END IF;
+
+    IF NOT s_short_name THEN
+      p_short_name := NULL;
+    END IF;
+
+    IF NOT s_date_of_birth THEN
+      p_date_of_birth := NULL;
+    END IF;
+
+    IF NOT s_date_of_death THEN
+      p_date_of_death := NULL;
+    END IF;
+
+    IF NOT s_address THEN
+      p_address := NULL;
+    END IF;
+
+    IF NOT s_mailing_address THEN
+      p_mailing_address := NULL;
+    END IF;
+
+    -- Validate required fields
     IF NOT s_source THEN
-        RAISE EXCEPTION 'null value in column "source" of relation "person" violates not-null constraint'
+      RAISE EXCEPTION 'null value in column "source" of relation "person" violates not-null constraint'
         USING ERRCODE = '23502'
             , SCHEMA = 'register'
             , TABLE = 'person'
@@ -94,14 +143,14 @@
   ELSE
     -- Update the person
     UPDATE register.person p
-    SET first_name = p_first_name
-      , middle_name = p_middle_name
-      , last_name = p_last_name
-      , short_name = p_short_name
-      , date_of_birth = p_date_of_birth
-      , date_of_death = p_date_of_death
-      , address = p_address
-      , mailing_address = p_mailing_address
+    SET first_name = CASE WHEN s_first_name THEN p_first_name ELSE p.first_name END
+      , middle_name = CASE WHEN s_middle_name THEN p_middle_name ELSE p.middle_name END
+      , last_name = CASE WHEN s_last_name THEN p_last_name ELSE p.last_name END
+      , short_name = CASE WHEN s_short_name THEN p_short_name ELSE p.short_name END
+      , date_of_birth = CASE WHEN s_date_of_birth THEN p_date_of_birth ELSE p.date_of_birth END
+      , date_of_death = CASE WHEN s_date_of_death THEN p_date_of_death ELSE p.date_of_death END
+      , address = CASE WHEN s_address THEN p_address ELSE p.address END
+      , mailing_address = CASE WHEN s_mailing_address THEN p_mailing_address ELSE p.mailing_address END
       , source = CASE
           WHEN s_source THEN p_source
           ELSE p.source
```

## v0.53-edu-ext-ref/01-update-si-user.sql -> 06-upsert-self-identified-user.sql

```diff
--- src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.53-edu-ext-ref/01-update-si-user.sql	2026-04-14 16:15:16.452743373 +0200
+++ src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/06-upsert-self-identified-user.sql	2026-05-07 17:54:27.022247249 +0200
@@ -1,11 +1,15 @@
 CREATE OR REPLACE FUNCTION register.upsert_self_identified_user(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
   INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
   INOUT p_id register.party.id%TYPE,
   INOUT p_ext_urn register.party.ext_urn%TYPE,
   INOUT p_user_ids bigint[],
   IN s_username boolean,
   INOUT p_username text,
   INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
   INOUT p_display_name register.party.display_name%TYPE,
   INOUT p_person_identifier register.party.person_identifier%TYPE,
   INOUT p_organization_identifier register.party.organization_identifier%TYPE,
@@ -47,13 +51,17 @@
   -- Upsert the party
   SELECT *
   FROM register.upsert_party(
+    p_flags,
+    s_uuid,
     p_uuid,
+    s_id,
     p_id,
     p_ext_urn,
     p_user_ids,
     s_username,
     p_username,
     p_party_type,
+    s_display_name,
     p_display_name,
     p_person_identifier,
     p_organization_identifier,
```

v0.46-extref/04-upsert-system-user.sql -> 07-upsert-system-user.sql

```diff
--- src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.46-extref/04-upsert-system-user.sql	2026-04-07 17:26:31.695543410 +0200
+++ src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.55-mk-party/07-upsert-system-user.sql	2026-05-07 17:54:27.022247249 +0200
@@ -1,11 +1,15 @@
 CREATE OR REPLACE FUNCTION register.upsert_system_user(
+  IN p_flags register.db_feature_flag[],
+  IN s_uuid boolean,
   INOUT p_uuid register.party.uuid%TYPE,
+  IN s_id boolean,
   INOUT p_id register.party.id%TYPE,
   INOUT p_ext_urn register.party.ext_urn%TYPE,
   INOUT p_user_ids bigint[],
   IN s_username boolean,
   INOUT p_username text,
   INOUT p_party_type register.party.party_type%TYPE,
+  IN s_display_name boolean,
   INOUT p_display_name register.party.display_name%TYPE,
   INOUT p_person_identifier register.party.person_identifier%TYPE,
   INOUT p_organization_identifier register.party.organization_identifier%TYPE,
@@ -29,13 +33,17 @@
   -- Upsert the party
   SELECT *
   FROM register.upsert_party(
+    p_flags,
+    s_uuid,
     p_uuid,
+    s_id,
     p_id,
     p_ext_urn,
     p_user_ids,
     s_username,
     p_username,
     p_party_type,
+    s_display_name,
     p_display_name,
     p_person_identifier,
     p_organization_identifier,
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced feature flag support for party persistence operations, enabling controlled auto-generation of party identifiers for organizations, persons, and specialized user types.

* **Chores**
  * Enhanced database schema with performance optimization and new data structures to support party management operations.
  * Updated persistence layer to integrate feature flag controls throughout party record creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->