### PR TITLE
feat: add storage queue jobs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,7 @@
     "BaseArtifactsPath",
     "ArtifactsPath",
     "VersionFilePath"
-  ]
+  ],
+  "csharp.debug.justMyCode": false,
+  "csharp.debug.requireExactSource": false
 }

--- a/Altinn.Register.sln
+++ b/Altinn.Register.sln
@@ -65,6 +65,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.Servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.AzureIdentity.Tests", "src\apps\Altinn.Register\test\ServiceDefaults.AzureIdentity.Tests\Altinn.Authorization.ServiceDefaults.AzureIdentity.Tests.csproj", "{09E293EA-E4AC-4B46-B3C1-6255063DA836}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.StorageQueues", "src\apps\Altinn.Register\src\ServiceDefaults.StorageQueues\Altinn.Authorization.ServiceDefaults.StorageQueues.csproj", "{721DEA06-9F0C-48FB-9642-E4B498CC6772}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.StorageQueues.Tests", "src\apps\Altinn.Register\test\ServiceDefaults.StorageQueues.Tests\Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.csproj", "{534AC70E-2B78-4268-AD52-172DBEB4C4AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -351,6 +355,30 @@ Global
 		{09E293EA-E4AC-4B46-B3C1-6255063DA836}.Release|x64.Build.0 = Release|Any CPU
 		{09E293EA-E4AC-4B46-B3C1-6255063DA836}.Release|x86.ActiveCfg = Release|Any CPU
 		{09E293EA-E4AC-4B46-B3C1-6255063DA836}.Release|x86.Build.0 = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|x64.Build.0 = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Debug|x86.Build.0 = Debug|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|Any CPU.Build.0 = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|x64.ActiveCfg = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|x64.Build.0 = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|x86.ActiveCfg = Release|Any CPU
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772}.Release|x86.Build.0 = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|x64.Build.0 = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Debug|x86.Build.0 = Debug|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|x64.ActiveCfg = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|x64.Build.0 = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -385,6 +413,8 @@ Global
 		{D4A53A4B-705E-4D07-9678-F2065DF6FFF0} = {9F856603-52D5-E1B8-657B-994E194BE88D}
 		{E49FD692-2CAE-4D59-B202-8A084099BF6D} = {9F856603-52D5-E1B8-657B-994E194BE88D}
 		{09E293EA-E4AC-4B46-B3C1-6255063DA836} = {3727DEF6-1C14-53EF-AF3C-EDAF252F0EAE}
+		{721DEA06-9F0C-48FB-9642-E4B498CC6772} = {9F856603-52D5-E1B8-657B-994E194BE88D}
+		{534AC70E-2B78-4268-AD52-172DBEB4C4AB} = {3727DEF6-1C14-53EF-AF3C-EDAF252F0EAE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E43BF31D-5B8F-4501-B804-BB47D2A9652A}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.2" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
     <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="JWTCookieAuthentication" Version="4.0.4" />
@@ -48,16 +49,16 @@
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.14" />
     <PackageVersion Include="Microsoft.Build.Artifacts" Version="6.1.63" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
@@ -81,6 +82,7 @@
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.7" />
     <PackageVersion Include="System.Text.Json" Version="9.0.14" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Sftp" Version="4.11.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.15.0" />

--- a/src/apps/Altinn.Register/Altinn.Register.sln
+++ b/src/apps/Altinn.Register/Altinn.Register.sln
@@ -55,6 +55,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.Servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.AzureIdentity.Tests", "test\ServiceDefaults.AzureIdentity.Tests\Altinn.Authorization.ServiceDefaults.AzureIdentity.Tests.csproj", "{80682655-7624-421B-8644-78607B7EC19D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.StorageQueues", "src\ServiceDefaults.StorageQueues\Altinn.Authorization.ServiceDefaults.StorageQueues.csproj", "{94BFFF14-5682-4523-AB85-A4069F00B530}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ServiceDefaults.StorageQueues.Tests", "test\ServiceDefaults.StorageQueues.Tests\Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.csproj", "{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -329,6 +333,30 @@ Global
 		{80682655-7624-421B-8644-78607B7EC19D}.Release|x64.Build.0 = Release|Any CPU
 		{80682655-7624-421B-8644-78607B7EC19D}.Release|x86.ActiveCfg = Release|Any CPU
 		{80682655-7624-421B-8644-78607B7EC19D}.Release|x86.Build.0 = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|x64.Build.0 = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Debug|x86.Build.0 = Debug|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|x64.ActiveCfg = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|x64.Build.0 = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|x86.ActiveCfg = Release|Any CPU
+		{94BFFF14-5682-4523-AB85-A4069F00B530}.Release|x86.Build.0 = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|x64.Build.0 = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Debug|x86.Build.0 = Debug|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|x64.ActiveCfg = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|x64.Build.0 = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|x86.ActiveCfg = Release|Any CPU
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -357,5 +385,7 @@ Global
 		{6A6044E2-7BAB-47EB-84E6-9BDD819C78A0} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{00DB1D78-83DC-4B74-A71D-ABE36E785098} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{80682655-7624-421B-8644-78607B7EC19D} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
+		{94BFFF14-5682-4523-AB85-A4069F00B530} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{4EA4B21A-CC1F-419E-8A42-26F2B08DE5AE} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 EndGlobal

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Altinn.Authorization.ServiceDefaults.StorageQueues.csproj
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Altinn.Authorization.ServiceDefaults.StorageQueues.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ServiceDefaults.AzureIdentity/Altinn.Authorization.ServiceDefaults.AzureIdentity.csproj" />
+    <ProjectReference Include="../ServiceDefaults.Jobs/Altinn.Authorization.ServiceDefaults.Jobs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Altinn.Authorization.ServiceDefaults.StorageQueues.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/DefaultStorageQueueClientFactory.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/DefaultStorageQueueClientFactory.cs
@@ -1,0 +1,15 @@
+using Azure.Core;
+using Azure.Storage.Queues;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Default implementation of <see cref="IStorageQueueClientFactory"/>.
+/// </summary>
+internal sealed class DefaultStorageQueueClientFactory
+    : IStorageQueueClientFactory
+{
+    /// <inheritdoc/>
+    public QueueClient CreateClient(Uri accountUri, string queueName, TokenCredential credential)
+        => new QueueClient(new Uri(accountUri, queueName), credential);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IQueueJobSettings.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IQueueJobSettings.cs
@@ -1,0 +1,42 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Represents settings for a storage queue job.
+/// </summary>
+public interface IQueueJobSettings
+{
+    /// <summary>
+    /// Gets or sets the minimum interval between job executions.
+    /// </summary>
+    public TimeSpan MinimumInterval { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum interval between job executions.
+    /// </summary>
+    public TimeSpan MaximumInterval { get; set; }
+
+    /// <summary>
+    /// Gets or sets the delta backoff interval. Defaults to <see cref="MinimumInterval"/> if <see langword="null"/>.
+    /// </summary>
+    public TimeSpan? DeltaBackoff { get; set; }
+
+    /// <summary>
+    /// Gets a collection of tags that can be used to categorize the job.
+    /// </summary>
+    public ISet<string> Tags { get; }
+
+    /// <summary>
+    /// Gets or sets a delegate that will be called to check if the job is enabled or not.
+    /// </summary>
+    /// <remarks>
+    /// This delegate will be called before each time the job is scheduled to run, and it runs in singleton scope.
+    /// </remarks>
+    public Func<IServiceProvider, CancellationToken, ValueTask<JobShouldRunResult>>? Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate that will be called before the first job from a job registration is run.
+    /// </summary>
+    public Func<IServiceProvider, CancellationToken, ValueTask>? WaitForReady { get; set; }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueClientFactory.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueClientFactory.cs
@@ -1,0 +1,19 @@
+using Azure.Core;
+using Azure.Storage.Queues;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Factory for creating <see cref="QueueClient"/> instances.
+/// </summary>
+public interface IStorageQueueClientFactory
+{
+    /// <summary>
+    /// Creates a <see cref="QueueClient"/> for the specified storage account URI, queue name, and credential.
+    /// </summary>
+    /// <param name="accountUri">The URI of the storage account.</param>
+    /// <param name="queueName">The name of the queue.</param>
+    /// <param name="credential">The token credential to use for authentication.</param>
+    /// <returns>A <see cref="QueueClient"/> instance.</returns>
+    QueueClient CreateClient(Uri accountUri, string queueName, TokenCredential credential);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageHandler.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageHandler.cs
@@ -1,0 +1,22 @@
+using Azure.Storage.Queues.Models;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Interface for handling messages from Azure Storage Queues.
+/// </summary>
+/// <remarks>
+/// All handlers <strong>must</strong> be idempotent. Azure Queue Storage provides
+/// at-least-once delivery, so messages can be received multiple times after failures,
+/// cancellation, visibility timeout expiry, or delete failures.
+/// </remarks>
+public interface IStorageQueueMessageHandler
+{
+    /// <summary>
+    /// Handles a message from the queue. If the method completes successfully, the message is deleted from the queue.
+    /// </summary>
+    /// <param name="message">The message to handle.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public Task HandleMessageAsync(QueueMessage message, CancellationToken cancellationToken);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageSender.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageSender.cs
@@ -1,0 +1,14 @@
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Defines an interface for sending messages to a storage queue, abstracting away the underlying implementation details.
+/// </summary>
+public interface IStorageQueueMessageSender
+{
+    /// <summary>
+    /// Sends a message to the storage queue.
+    /// </summary>
+    /// <param name="message">The message content to send. Must be valid UTF-8.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    public Task SendMessageAsync(BinaryData message, CancellationToken cancellationToken = default);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageSenderFactory.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/IStorageQueueMessageSenderFactory.cs
@@ -1,0 +1,14 @@
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Defines a factory interface for creating instances of <see cref="IStorageQueueMessageSender"/>.
+/// </summary>
+public interface IStorageQueueMessageSenderFactory
+{
+    /// <summary>
+    /// Creates a sender used to send messages to a storage queue.
+    /// </summary>
+    /// <param name="name">The name of the configuration to use.</param>
+    /// <returns>A <see cref="IStorageQueueMessageSender"/> instance.</returns>
+    public IStorageQueueMessageSender CreateSender(string name);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Microsoft.Extensions.DependencyInjection/StorageQueuesServiceCollectionExtensions.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Microsoft.Extensions.DependencyInjection/StorageQueuesServiceCollectionExtensions.cs
@@ -1,0 +1,237 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+using Altinn.Authorization.ServiceDefaults.Jobs.DelayStrategies;
+using Altinn.Authorization.ServiceDefaults.StorageQueues;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Utils;
+using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/>.
+/// </summary>
+public static class StorageQueuesServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Adds a storage queue job to the service collection.
+        /// </summary>
+        /// <typeparam name="T">The handler type.</typeparam>
+        /// <param name="name">The job name.</param>
+        /// <param name="configure">A delegate to configure the job settings.</param>
+        /// <returns>The job registration.</returns>
+        /// <remarks>
+        /// The <paramref name="name"/> parameter is used to look up the storage queue settings.
+        /// </remarks>
+        public OptionsBuilder<StorageQueueSettings> AddStorageQueueJob<T>(
+            string name,
+            Action<IQueueJobSettings> configure)
+            where T : class, IStorageQueueMessageHandler
+        {
+            var settings = new QueueJobSettings();
+            configure(settings);
+
+            var builder = services.AddStorageQueue(name);
+
+            services.TryAddScoped<T>();
+            services.AddRecurringJob(new QueueJobRegistration<T>(
+                name: name,
+                minimumInterval: settings.MinimumInterval,
+                maximumInterval: settings.MaximumInterval,
+                deltaBackoff: settings.DeltaBackoff ?? settings.MinimumInterval,
+                tags: settings.Tags,
+                enabled: settings.Enabled,
+                waitForReady: settings.WaitForReady));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a storage queue client factory and configures storage queue settings for the specified name.
+        /// </summary>
+        /// <param name="name">The name of the storage queue.</param>
+        /// <returns>The options builder for the storage queue settings.</returns>
+        public OptionsBuilder<StorageQueueSettings> AddStorageQueue(string name)
+        {
+            services.AddTokenCredentialProvider();
+            services.TryAddSingleton<StorageQueueFactory>();
+            services.TryAddSingleton<IStorageQueueClientFactory, DefaultStorageQueueClientFactory>();
+            services.TryAddSingleton<IStorageQueueMessageSenderFactory>(s => s.GetRequiredService<StorageQueueFactory>());
+
+            var builder = services.AddOptions<StorageQueueSettings>(name)
+                .ValidateDataAnnotations();
+
+            return builder;
+        }
+    }
+
+    private sealed class QueueJobRegistration<T>
+        : JobRegistration<StorageQueuePollJobRunResult>
+        where T : class, IStorageQueueMessageHandler
+    {
+        private static readonly ObjectFactory<StorageQueuePollJob<T>> _factory
+            = ActivatorUtilities.CreateFactory<StorageQueuePollJob<T>>([typeof(StorageQueueReceiver)]);
+
+        private readonly string _name;
+
+        public QueueJobRegistration(
+            string name,
+            TimeSpan minimumInterval,
+            TimeSpan maximumInterval,
+            TimeSpan deltaBackoff,
+            IEnumerable<string> tags,
+            Func<IServiceProvider, CancellationToken, ValueTask<JobShouldRunResult>>? enabled,
+            Func<IServiceProvider, CancellationToken, ValueTask>? waitForReady)
+            : base(
+                name: $"storage-queue-poll: {name}",
+                leaseName: null, // all instances can process queue message
+                delayStrategy: new RandomizedExponentialBackoffStrategy(minimumInterval, maximumInterval, deltaBackoff),
+                runAt: JobHostLifecycles.None, // only run as a scheduled job, not on startup or shutdown
+                tags: tags,
+                enabled: enabled,
+                waitForReady: waitForReady)
+        {
+            _name = name;
+        }
+
+        protected override IJob<StorageQueuePollJobRunResult> Create(IServiceProvider services)
+        {
+            var factory = services.GetRequiredService<StorageQueueFactory>();
+            var receiver = factory.CreateReceiver(_name);
+
+            return _factory(services, [receiver]);
+        }
+    }
+
+    /// <summary>
+    /// A delay strategy that implements a randomized exponential backoff algorithm, with the ability to reset the backoff when certain job results are observed.
+    /// </summary>
+    internal sealed class RandomizedExponentialBackoffStrategy
+        : IDelayStrategy<StorageQueuePollJobRunResult>
+    {
+        private static readonly TimeSpan SkippedDelay = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// The maximum randomization factor to apply to the calculated backoff interval.
+        /// </summary>
+        public const double RandomizationFactor = 0.2;
+
+        private readonly TimeSpan _minimumInterval;
+        private readonly TimeSpan _maximumInterval;
+        private readonly TimeSpan _deltaBackoff;
+
+        private readonly Random _random;
+
+        private TimeSpan _currentInterval;
+        private uint _backoffExponent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomizedExponentialBackoffStrategy"/> class.
+        /// </summary>
+        /// <param name="minimumInterval">The minimum interval between job executions.</param>
+        /// <param name="maximumInterval">The maximum interval between job executions.</param>
+        /// <param name="deltaBackoff">The delta backoff interval.</param>
+        public RandomizedExponentialBackoffStrategy(
+            TimeSpan minimumInterval,
+            TimeSpan maximumInterval,
+            TimeSpan deltaBackoff)
+        {
+            Guard.IsGreaterThan(minimumInterval, TimeSpan.Zero);
+            Guard.IsGreaterThan(maximumInterval, TimeSpan.Zero);
+            Guard.IsGreaterThan(deltaBackoff, TimeSpan.Zero);
+
+            if (minimumInterval.Ticks > maximumInterval.Ticks)
+            {
+                ThrowHelper.ThrowArgumentException(nameof(minimumInterval), "The minimumInterval must not be greater than the maximumInterval.");
+            }
+
+            _minimumInterval = minimumInterval;
+            _maximumInterval = maximumInterval;
+            _deltaBackoff = deltaBackoff;
+            _random = new();
+        }
+
+        /// <inheritdoc/>
+        public string Description
+            => $"randomized-exponential-backoff (min: {_minimumInterval}, max: {_maximumInterval}, delta: {_deltaBackoff})";
+
+        /// <inheritdoc/>
+        public TimeSpan GetDelay(JobOutcome<StorageQueuePollJobRunResult> outcome)
+        {
+            if (outcome is { IsJobSuccess: true, Result: StorageQueuePollJobRunResult.MultiplePages })
+            {
+                // we received multiple pages of messages, so there is likely to be more work to do shortly. Delay the minimum amount of time.
+                _currentInterval = _minimumInterval;
+                _backoffExponent = 1;
+            }
+            else if (outcome.IsJobSkipped)
+            {
+                _currentInterval = _maximumInterval;
+                return SkippedDelay;
+            }
+            else if (
+
+                // if there is exactly 1 page of messages, we assume that we're in somewhat of an equalibrium, so we keep the current delay.
+                outcome is not { IsJobSuccess: true, Result: StorageQueuePollJobRunResult.SinglePage }
+
+                // if the currentInterval is already at the maximum, we also keep it
+                && _currentInterval != _maximumInterval)
+            {
+                TimeSpan backoffInterval = _minimumInterval;
+
+                if (_backoffExponent > 0)
+                {
+                    double incrementMsec = _random.Next(1.0 - RandomizationFactor, 1.0 + RandomizationFactor)
+                        * Math.Pow(2.0, _backoffExponent - 1)
+                        * _deltaBackoff.TotalMilliseconds;
+
+                    backoffInterval += TimeSpan.FromMilliseconds(incrementMsec);
+                }
+
+                if (backoffInterval < _maximumInterval)
+                {
+                    _currentInterval = backoffInterval;
+                    _backoffExponent++;
+                }
+                else
+                {
+                    _currentInterval = _maximumInterval;
+                }
+            }
+
+            return _currentInterval;
+        }
+    }
+
+    private sealed class QueueJobSettings()
+        : IQueueJobSettings
+    {
+        /// <inheritdoc/>
+        public ISet<string> Tags { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <inheritdoc/>
+        public Func<IServiceProvider, CancellationToken, ValueTask<JobShouldRunResult>>? Enabled { get; set; } = null;
+
+        /// <inheritdoc/>
+        public Func<IServiceProvider, CancellationToken, ValueTask>? WaitForReady { get; set; } = null;
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The default value of 100ms is taken from Azure Function's backoff strategy.
+        /// </remarks>
+        public TimeSpan MinimumInterval { get; set; }
+            = TimeSpan.FromMilliseconds(100);
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The default value of 1 minute is taken from Azure Function's backoff strategy.
+        /// </remarks>
+        public TimeSpan MaximumInterval { get; set; }
+            = TimeSpan.FromMinutes(1);
+
+        /// <inheritdoc/>
+        public TimeSpan? DeltaBackoff { get; set; }
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueFactory.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueFactory.cs
@@ -1,0 +1,72 @@
+using Altinn.Authorization.ServiceDefaults.AzureIdentity;
+using Azure.Storage.Queues;
+using CommunityToolkit.Diagnostics;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Factory for creating <see cref="QueueClient"/> instances based on named settings.
+/// </summary>
+internal sealed class StorageQueueFactory
+    : IStorageQueueMessageSenderFactory
+{
+    private readonly IOptionsMonitor<StorageQueueSettings> _settings;
+    private readonly ITokenCredentialProvider _credentialProvider;
+    private readonly IStorageQueueClientFactory _clientFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StorageQueueFactory"/> class.
+    /// </summary>
+    public StorageQueueFactory(
+        ITokenCredentialProvider credentialProvider,
+        IStorageQueueClientFactory clientFactory,
+        IOptionsMonitor<StorageQueueSettings> settings)
+    {
+        _credentialProvider = credentialProvider;
+        _clientFactory = clientFactory;
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Creates a receiver used to receive messages from a storage queue.
+    /// </summary>
+    /// <param name="name">The name of the configuration to use.</param>
+    /// <returns>A <see cref="StorageQueueReceiver"/> instance.</returns>
+    public StorageQueueReceiver CreateReceiver(string name)
+    {
+        var settings = _settings.Get(name);
+
+        if (string.IsNullOrWhiteSpace(settings.PoisonQueueName))
+        {
+            ThrowHelper.ThrowInvalidOperationException($"Poison queue name must be specified for storage queue '{name}'.");
+        }
+
+        if (string.Equals(settings.QueueName, settings.PoisonQueueName, StringComparison.OrdinalIgnoreCase))
+        {
+            ThrowHelper.ThrowInvalidOperationException($"Queue name and poison queue name cannot be the same for storage queue '{name}'.");
+        }
+
+        var credential = _credentialProvider.GetCredential(settings.IdentityName);
+        var queue = _clientFactory.CreateClient(settings.StorageAccountUri!, settings.QueueName!, credential);
+        var poison = _clientFactory.CreateClient(settings.StorageAccountUri!, settings.PoisonQueueName!, credential);
+        return new(queue, poison);
+    }
+
+    /// <summary>
+    /// Creates a sender used to send messages to a storage queue.
+    /// </summary>
+    /// <param name="name">The name of the configuration to use.</param>
+    /// <returns>A <see cref="StorageQueueSender"/> instance.</returns>
+    public StorageQueueSender CreateSender(string name)
+    {
+        var settings = _settings.Get(name);
+        var credential = _credentialProvider.GetCredential(settings.IdentityName);
+        var queue = _clientFactory.CreateClient(settings.StorageAccountUri!, settings.QueueName!, credential);
+        return new(queue);
+    }
+
+    /// <inheritdoc/>
+    IStorageQueueMessageSender IStorageQueueMessageSenderFactory.CreateSender(string name)
+        => CreateSender(name);
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueuePollJob.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueuePollJob.cs
@@ -1,0 +1,176 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// A background job that polls an Azure Storage Queue for messages and processes them using a specified message handler.
+/// The job completes once the queue is empty or the cancellation token is triggered.
+/// </summary>
+/// <typeparam name="T">The type of the message handler used to process messages from the queue.</typeparam>
+internal sealed partial class StorageQueuePollJob<T>
+    : Job<StorageQueuePollJobRunResult>
+    where T : class, IStorageQueueMessageHandler
+{
+    // TODO: configurable?
+    private static readonly int MaxRetries = 5;
+    private static readonly int BatchSize = 32;
+    private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(10); // note: this can be exceeded by jitter
+    private static readonly TimeSpan BackoffJitter = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan InvisibilityTimeout = TimeSpan.FromMinutes(10);
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<StorageQueuePollJob<T>> _logger;
+    private readonly StorageQueueReceiver _receiver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StorageQueuePollJob{T}"/> class.
+    /// </summary>
+    public StorageQueuePollJob(
+        StorageQueueReceiver receiver,
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<StorageQueuePollJob<T>> logger)
+    {
+        _receiver = receiver;
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<StorageQueuePollJobRunResult> RunAsync(CancellationToken cancellationToken = default)
+    {
+        Task?[] processingTasks = new Task?[BatchSize];
+
+        uint pagesProcessed = 0;
+        await foreach (var messages in _receiver.ReceiveAllMessageAsync(
+            batchSize: BatchSize,
+            visibilityTimeout: InvisibilityTimeout,
+            cancellationToken: cancellationToken))
+        {
+            Array.Clear(processingTasks);
+
+            // TODO: deal with parallelism better. Instead of doing a batch at a time
+            // we want to have a configured degree of parallelism and keep that many
+            // tasks running as long as there are messages to process.
+            for (int i = 0; i < messages.Length; i++)
+            {
+                var message = messages[i];
+                processingTasks[i] = ProcessMessageAsync(message, cancellationToken);
+            }
+
+            await Task.WhenAll(processingTasks.AsSpan(0, messages.Length)!);
+            pagesProcessed++;
+        }
+
+        return pagesProcessed switch
+        {
+            0 => StorageQueuePollJobRunResult.NoPages,
+            1 => StorageQueuePollJobRunResult.SinglePage,
+            _ => StorageQueuePollJobRunResult.MultiplePages,
+        };
+    }
+
+    private async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+    {
+        // Ensure that the caller can continue creating the processingTasks array without waiting for any processing to complete
+        await Task.Yield();
+
+        // Check if the message has been retried too many times
+        if (message.DequeueCount > MaxRetries)
+        {
+            // Move the message to the poison queue for later inspection
+            await TryMoveToPoisonQueueAsync(_receiver, message, _logger, cancellationToken);
+            return;
+        }
+
+        try
+        {
+            await using var scope = _serviceScopeFactory.CreateAsyncScope();
+            var handler = scope.ServiceProvider.GetRequiredService<T>();
+            await handler.HandleMessageAsync(message, cancellationToken);
+            await _receiver.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Operation was cancelled, likely due to shutdown. Let the message become visible again for processing by another instance.
+        }
+        catch (Exception ex)
+        {
+            // Log the exception and update visibility with backoff
+            Log.MessageFailed(_logger, message.MessageId, ex);
+
+            if (message.DequeueCount == MaxRetries)
+            {
+                // If this was the last retry, no need to schedule another attempt that will only move it to the poison queue.
+                await TryMoveToPoisonQueueAsync(_receiver, message, _logger, cancellationToken);
+                return;
+            }
+
+            // 30 seconds, 1 minute, 2 minutes, 4 minutes, ...
+            var jitter = RandomJitter();
+            var backoff = (MinBackoff * Math.Pow(2, message.DequeueCount - 1)) + jitter;
+            if (backoff > MaxBackoff)
+            {
+                backoff = MaxBackoff + jitter;
+            }
+
+            await TryRescheduleMAsync(_receiver, message, backoff, _logger, cancellationToken);
+        }
+
+        static async Task TryRescheduleMAsync(StorageQueueReceiver receiver, QueueMessage message, TimeSpan backoff, ILogger logger, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await receiver.RescheduleMessageAsync(message, backoff, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Operation was cancelled, likely due to shutdown. Let the message become visible again for processing by another instance.
+            }
+            catch (Exception updateEx)
+            {
+                // Log the exception but do not rethrow. The message will become visible again after the original invisibility timeout
+                Log.VisibilityUpdateFailed(logger, message.MessageId, updateEx);
+            }
+        }
+
+        static async Task TryMoveToPoisonQueueAsync(StorageQueueReceiver receiver, QueueMessage message, ILogger logger, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await receiver.MoveToPoisonQueueAsync(message, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Operation was cancelled, likely due to shutdown. Let the message become visible again for processing by another instance.
+            }
+            catch (Exception moveEx)
+            {
+                // Log the exception but do not rethrow. The message will become visible again after the original invisibility timeout
+                Log.MoveToPoisonQueueFailed(logger, message.MessageId, moveEx);
+            }
+        }
+    }
+
+    private static TimeSpan RandomJitter()
+    {
+        var random = Random.Shared.NextDouble();
+        var jitter = random * BackoffJitter.TotalSeconds;
+        return TimeSpan.FromSeconds(jitter);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Error, "Failed to process message with ID {MessageId}.")]
+        public static partial void MessageFailed(ILogger logger, string messageId, Exception exception);
+
+        [LoggerMessage(1, LogLevel.Error, "Failed to update visibility timeout for message with ID {MessageId}.")]
+        public static partial void VisibilityUpdateFailed(ILogger logger, string messageId, Exception exception);
+
+        [LoggerMessage(2, LogLevel.Error, "Failed to move message with ID {MessageId} to the poison queue.")]
+        public static partial void MoveToPoisonQueueFailed(ILogger logger, string messageId, Exception exception);
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueuePollJobRunResult.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueuePollJobRunResult.cs
@@ -1,0 +1,11 @@
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// The result of a <see cref="StorageQueuePollJob{T}"/> run, indicating whether any messages were processed.
+/// </summary>
+internal enum StorageQueuePollJobRunResult
+{
+    NoPages,
+    SinglePage,
+    MultiplePages,
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueReceiver.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueReceiver.cs
@@ -1,0 +1,86 @@
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Utils;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Represents a receiver for an Azure Storage Queue, providing methods to receive messages
+/// in batches and move messages to a poison queue when necessary.
+/// </summary>
+internal sealed class StorageQueueReceiver
+{
+    private readonly QueueClient _queue;
+    private readonly QueueClient _poison;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StorageQueueReceiver"/> class.
+    /// </summary>
+    /// <param name="queue">The primary queue client.</param>
+    /// <param name="poison">The poison queue client.</param>
+    public StorageQueueReceiver(QueueClient queue, QueueClient poison)
+    {
+        _queue = queue;
+        _poison = poison;
+    }
+
+    /// <summary>
+    /// Receives messages from the queue in batches, yielding them batch by batch. The method continues to receive messages
+    /// until the cancellation token is triggered or no more messages are available.
+    /// </summary>
+    /// <param name="batchSize">The maximum number of messages to fetch in a single batch.</param>
+    /// <param name="visibilityTimeout">The duration for which the received messages are invisible to other consumers.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An asynchronous stream of queue messages.</returns>
+    /// <remarks>
+    /// If the batch size is larger than what can be processed within the visibility timeout,
+    /// there is an (increased) risk of messages being produced multiple times.
+    /// </remarks>
+    public IAsyncEnumerable<QueueMessage[]> ReceiveAllMessageAsync(
+        int batchSize,
+        TimeSpan visibilityTimeout,
+        CancellationToken cancellationToken = default)
+        => _queue.ReceiveAllMessageAsync(batchSize, visibilityTimeout, cancellationToken);
+
+    /// <summary>
+    /// Moves the specified message to the poison queue and deletes it from the original queue.
+    /// This is typically used when a message has exceeded the maximum number of processing attempts
+    /// and needs to be set aside for later inspection.
+    /// </summary>
+    /// <param name="message">The message to move to the poison queue.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task MoveToPoisonQueueAsync(QueueMessage message, CancellationToken cancellationToken = default)
+    {
+        await _poison.SendMessageAsync(message.Body, cancellationToken: cancellationToken);
+        await _queue.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+    }
+
+    /// <summary>
+    /// Marks a message as completed by deleting it from the queue.
+    /// </summary>
+    /// <param name="message">The message to mark as completed.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task CompleteMessageAsync(QueueMessage message, CancellationToken cancellationToken = default)
+    {
+        await _queue.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reschedules a message by updating its visibility timeout, making it invisible for a specified delay period.
+    /// </summary>
+    /// <param name="message">The message to reschedule.</param>
+    /// <param name="delay">The duration for which the message should be invisible.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>The message's dequeue count will still have been incremented</remarks>
+    public async Task RescheduleMessageAsync(QueueMessage message, TimeSpan delay, CancellationToken cancellationToken = default)
+    {
+        await _queue.UpdateMessageAsync(
+            messageId: message.MessageId,
+            popReceipt: message.PopReceipt,
+            visibilityTimeout: delay,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueSender.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueSender.cs
@@ -1,0 +1,31 @@
+using Azure.Storage.Queues;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// A sender for Azure Storage Queues.
+/// </summary>
+internal sealed class StorageQueueSender
+    : IStorageQueueMessageSender
+{
+    private readonly QueueClient _queue;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="StorageQueueSender"/> class with the specified <see cref="QueueClient"/>.
+    /// </summary>
+    /// <param name="queue">The storage queue to send to.</param>
+    public StorageQueueSender(QueueClient queue)
+    {
+        _queue = queue;
+    }
+
+    /// <summary>
+    /// Sends a message to the storage queue.
+    /// </summary>
+    /// <param name="message">The message content to send. Must be valid UTF-8.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    public async Task SendMessageAsync(BinaryData message, CancellationToken cancellationToken = default)
+    {
+        await _queue.SendMessageAsync(message, visibilityTimeout: null, timeToLive: null, cancellationToken);
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueSettings.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/StorageQueueSettings.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues;
+
+/// <summary>
+/// Represents the settings required to configure a storage queue job, including the storage account name, queue name, and poison queue name.
+/// </summary>
+public sealed class StorageQueueSettings
+    : IValidatableObject
+{
+    private const string QueueNamePattern = "^[a-z0-9](?:-?[a-z0-9]){2,62}$";
+
+    /// <summary>
+    /// Gets the name of the azure identity to use when authenticating to the storage account.
+    /// </summary>
+    public string IdentityName { get; set; } = "storage";
+
+    /// <summary>
+    /// Gets the uri of the storage account containing the queue and poison queue.
+    /// </summary>
+    [Required]
+    public Uri? StorageAccountUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the queue to listen to for messages. The queue must exist in the specified storage account.
+    /// </summary>
+    [Required]
+    [RegularExpression(QueueNamePattern)]
+    public string? QueueName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the poison queue to move messages to after exceeding the maximum number of delivery attempts. The poison queue must exist in the specified storage account.
+    /// </summary>
+    [RegularExpression(QueueNamePattern)]
+    public string? PoisonQueueName { get; set; }
+
+    /// <inheritdoc/>
+    IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+    {
+        if (string.Equals(QueueName, PoisonQueueName, StringComparison.Ordinal))
+        {
+            yield return new ValidationResult("Queue name and poison queue name cannot be the same.", [nameof(QueueName), nameof(PoisonQueueName)]);
+        }
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Utils/QueueClientExtensions.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Utils/QueueClientExtensions.cs
@@ -1,0 +1,50 @@
+using System.Runtime.CompilerServices;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Utils;
+
+/// <summary>
+/// Extensions for <see cref="QueueClient"/>.
+/// </summary>
+internal static class QueueClientExtensions
+{
+    /// <param name="queue">The queue client.</param>
+    extension(QueueClient queue)
+    {
+        /// <summary>
+        /// Receives messages from the queue in batches, yielding them batch by batch. The method continues to receive messages
+        /// until the cancellation token is triggered or no more messages are available.
+        /// </summary>
+        /// <param name="batchSize">The maximum number of messages to fetch in a single batch.</param>
+        /// <param name="visibilityTimeout">The duration for which the received messages are invisible to other consumers.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>An asynchronous stream of queue messages.</returns>
+        /// <remarks>
+        /// If the batch size is larger than what can be processed within the visibility timeout,
+        /// there is an (increased) risk of messages being produced multiple times.
+        /// </remarks>
+        public async IAsyncEnumerable<QueueMessage[]> ReceiveAllMessageAsync(
+            int batchSize,
+            TimeSpan visibilityTimeout,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var response = await queue.ReceiveMessagesAsync(
+                    maxMessages: batchSize,
+                    visibilityTimeout: visibilityTimeout,
+                    cancellationToken: cancellationToken);
+
+                var messages = response.Value;
+                if (messages is not { Length: > 0 })
+                {
+                    // No more messages available
+                    yield break;
+                }
+
+                yield return messages;
+            }
+        }
+    }
+}

--- a/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Utils/RandomExtensions.cs
+++ b/src/apps/Altinn.Register/src/ServiceDefaults.StorageQueues/Utils/RandomExtensions.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Diagnostics;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Utils;
+
+/// <summary>
+/// Extensions for <see cref="Random"/>.
+/// </summary>
+internal static class RandomExtensions
+{
+    extension(Random random)
+    {
+        public double Next(double minValue, double maxValue)
+        {
+            if (minValue > maxValue)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(maxValue), "maxValue must be greater than or equal to minValue.");
+            }
+
+            return ((maxValue - minValue) * random.NextDouble()) + minValue;
+        }
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.csproj
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <XUnitVersion>v3</XUnitVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Testcontainers.Azurite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/ServiceDefaults.AzureIdentity/Altinn.Authorization.ServiceDefaults.AzureIdentity.csproj" />
+    <ProjectReference Include="../../src/ServiceDefaults.StorageQueues/Altinn.Authorization.ServiceDefaults.StorageQueues.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/AssemblyFixtures.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/AssemblyFixtures.cs
@@ -1,0 +1,3 @@
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+
+[assembly: AssemblyFixture(typeof(StorageFixture))]

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Fakes/TestStorageQueueClientFactory.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Fakes/TestStorageQueueClientFactory.cs
@@ -1,0 +1,18 @@
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Storage.Queues;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fakes;
+
+internal sealed class TestStorageQueueClientFactory(HttpPipelineTransport transport)
+    : IStorageQueueClientFactory
+{
+    public QueueClient CreateClient(Uri accountUri, string queueName, TokenCredential credential)
+        => new(
+            new Uri(accountUri, queueName),
+            credential,
+            new QueueClientOptions
+            {
+                Transport = transport,
+            });
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Fixtures/StorageFixture.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/Fixtures/StorageFixture.cs
@@ -1,0 +1,245 @@
+using System.Buffers.Text;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Storage.Queues;
+using Testcontainers.Azurite;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+
+internal sealed class StorageFixture
+    : IAsyncLifetime
+{
+    private const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.35.0";
+    private const string CertificatePath = "/certs/azurite.pem";
+    private const string PrivateKeyPath = "/certs/azurite-key.pem";
+
+    private readonly Lock _lock = new();
+    private Task<AzuriteContainer>? _startedTask = null;
+    private uint _queueCounter = 0;
+
+    public HttpPipelineTransport CreateTransport()
+    {
+        var handler = new HttpClientHandler
+        {
+            // We use a self-signed certificate for the container
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+
+        return new HttpClientTransport(handler);
+    }
+
+    public async Task<QueueInfo> CreateQueue()
+    {
+        var container = await EnsureContainerStartedAsync(CancellationToken.None);
+
+        var queueEndpoint = GetStorageAccountUri(container);
+        var client = new QueueServiceClient(
+            BuildConnectionString(container),
+            new QueueClientOptions
+            {
+                Transport = CreateTransport(),
+            });
+
+        var name = $"queue-{Interlocked.Increment(ref _queueCounter):D5}";
+        var poisonName = $"{name}-poison";
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await client.CreateQueueAsync(name, cancellationToken: cancellationToken);
+        await client.CreateQueueAsync(poisonName, cancellationToken: cancellationToken);
+
+        var credential = new StorageTokenCredential(subject: name);
+        return new QueueInfo
+        {
+            StorageAccountUri = queueEndpoint,
+            Credential = credential,
+            QueueName = name,
+            PoisonQueueName = poisonName,
+        };
+    }
+
+    public QueueClient CreateQueueClient(QueueInfo queue)
+        => CreateQueueClient(queue.StorageAccountUri, queue.QueueName, queue.Credential);
+
+    public QueueClient CreatePoisonQueueClient(QueueInfo queue)
+        => CreateQueueClient(queue.StorageAccountUri, queue.PoisonQueueName, queue.Credential);
+
+    public QueueClient CreateQueueClient(Uri storageAccountUri, string queueName, TokenCredential credential)
+        => new(
+            new Uri(storageAccountUri, queueName),
+            credential,
+            new QueueClientOptions
+            {
+                Transport = CreateTransport(),
+            });
+
+    /// <summary>
+    /// Lazily starts the underlying container exactly once, on the first call to
+    /// <see cref="CreateQueue"/>. Tests that never request a queue (the majority in the
+    /// assembly) don't pay the container-startup cost.
+    /// </summary>
+    private Task<AzuriteContainer> EnsureContainerStartedAsync(CancellationToken cancellationToken)
+    {
+        var task = Volatile.Read(ref _startedTask);
+        if (task is not null)
+        {
+            return task.WaitAsync(cancellationToken);
+        }
+
+        lock (_lock)
+        {
+            task = Volatile.Read(ref _startedTask);
+            if (task is not null)
+            {
+                return task.WaitAsync(cancellationToken);
+            }
+
+            task = StartContainerAsync();
+            Volatile.Write(ref _startedTask, task);
+            return task.WaitAsync(cancellationToken);
+        }
+
+        static async Task<AzuriteContainer> StartContainerAsync()
+        {
+            await Task.Yield();
+
+            var (certificatePem, privateKeyPem) = CreateSelfSignedCertificatePem();
+
+            var container = new AzuriteBuilder(AzuriteImage)
+                .WithResourceMapping(Encoding.ASCII.GetBytes(certificatePem), CertificatePath)
+                .WithResourceMapping(Encoding.ASCII.GetBytes(privateKeyPem), PrivateKeyPath)
+                .WithCommand(
+                    "--skipApiVersionCheck", // https://github.com/Azure/Azurite/issues/2651
+                    "--oauth",
+                    "basic",
+                    "--cert",
+                    CertificatePath,
+                    "--key",
+                    PrivateKeyPath)
+                .Build();
+            await container.StartAsync(CancellationToken.None);
+            return container;
+        }
+    }
+
+    ValueTask IAsyncLifetime.InitializeAsync() => ValueTask.CompletedTask;
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        Task<AzuriteContainer>? task;
+        lock (_lock)
+        {
+            task = Volatile.Read(ref _startedTask);
+        }
+
+        if (task is not null)
+        {
+            await (await task).DisposeAsync();
+        }
+    }
+
+    private static string BuildConnectionString(AzuriteContainer container)
+        => $"DefaultEndpointsProtocol=https;AccountName={AzuriteBuilder.AccountName};AccountKey={AzuriteBuilder.AccountKey};QueueEndpoint={GetStorageAccountUri(container)};";
+
+    private static Uri GetStorageAccountUri(AzuriteContainer container)
+        => new($"https://{container.Hostname}:{container.GetMappedPublicPort(AzuriteBuilder.QueuePort)}/{AzuriteBuilder.AccountName}/");
+
+    private static (string CertificatePem, string PrivateKeyPem) CreateSelfSignedCertificatePem()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=127.0.0.1",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(
+                certificateAuthority: false,
+                hasPathLengthConstraint: false,
+                pathLengthConstraint: 0,
+                critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+        request.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
+
+        var subjectAlternativeName = new SubjectAlternativeNameBuilder();
+        subjectAlternativeName.AddDnsName("localhost");
+        subjectAlternativeName.AddIpAddress(IPAddress.Loopback);
+        request.CertificateExtensions.Add(subjectAlternativeName.Build());
+
+        using var certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddDays(14));
+
+        return (certificate.ExportCertificatePem(), rsa.ExportPkcs8PrivateKeyPem());
+    }
+
+    private sealed class StorageTokenCredential(string subject)
+        : TokenCredential
+    {
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException("Only use async overloads");
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            const string tenantId = "00000000-0000-0000-0000-000000000000";
+            var now = DateTimeOffset.UtcNow;
+            var expires = now.AddHours(1);
+
+            using var rsa = RSA.Create(2048);
+            var header = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                alg = "RS256",
+                typ = "JWT",
+            }));
+
+            var payload = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                aud = "https://storage.azure.com/",
+                iss = $"https://sts.windows.net/{tenantId}/",
+                sub = subject,
+                appid = "11111111-1111-1111-1111-111111111111",
+                oid = Guid.CreateVersion7(), // object id
+                tid = tenantId, // tenant id
+                ver = "1.0",
+                iat = now.ToUnixTimeSeconds(), // issued at
+                nbf = now.ToUnixTimeSeconds(), // not before
+                exp = expires.ToUnixTimeSeconds(), // expires
+            }));
+
+            var signingInput = $"{header}.{payload}";
+            var signature = Base64Url.EncodeToString(rsa.SignData(
+                Encoding.ASCII.GetBytes(signingInput),
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1));
+
+            var jwt = $"{signingInput}.{signature}";
+            return ValueTask.FromResult(new AccessToken(jwt, expires));
+        }
+    }
+
+    public sealed class QueueInfo
+    {
+        public required Uri StorageAccountUri { get; init; }
+
+        public required TokenCredential Credential { get; init; }
+
+        public required string QueueName { get; init; }
+
+        public required string PoisonQueueName { get; init; }
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueDelayStrategyTests.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueDelayStrategyTests.cs
@@ -1,0 +1,155 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+using Strategy = Microsoft.Extensions.DependencyInjection.StorageQueuesServiceCollectionExtensions.RandomizedExponentialBackoffStrategy;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests;
+
+public sealed class StorageQueueDelayStrategyTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_WhenMinimumIntervalIsNotPositive_Throws(int milliseconds)
+    {
+        var ex = Should.Throw<ArgumentOutOfRangeException>(() => new Strategy(
+            TimeSpan.FromMilliseconds(milliseconds),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1)));
+
+        ex.ParamName.ShouldBe("minimumInterval");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_WhenMaximumIntervalIsNotPositive_Throws(int milliseconds)
+    {
+        var ex = Should.Throw<ArgumentOutOfRangeException>(() => new Strategy(
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(milliseconds),
+            TimeSpan.FromSeconds(1)));
+
+        ex.ParamName.ShouldBe("maximumInterval");
+    }
+
+    [Fact]
+    public void Constructor_WhenMinimumIsGreaterThanMaximum_Throws()
+    {
+        var ex = Should.Throw<ArgumentException>(() => new Strategy(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1)));
+
+        ex.ParamName.ShouldBe("minimumInterval");
+        ex.Message.ShouldContain("must not be greater than the maximumInterval");
+    }
+
+    [Fact]
+    public void Description_ContainsConfiguredIntervals()
+    {
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3));
+
+        strategy.Description.ShouldBe("randomized-exponential-backoff (min: 00:00:02, max: 00:00:10, delta: 00:00:03)");
+    }
+
+    [Fact]
+    public void GetDelay_WhenInitialOutcome_ReturnsMinimumInterval()
+    {
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3));
+
+        var delay = strategy.GetDelay(JobOutcome.None);
+
+        delay.ShouldBe(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void GetDelay_WhenSinglePageOutcome_KeepsCurrentDelay()
+    {
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3));
+
+        var first = strategy.GetDelay(JobOutcome.None);
+        var second = strategy.GetDelay(JobOutcome.Succeeded(StorageQueuePollJobRunResult.SinglePage));
+
+        first.ShouldBe(TimeSpan.FromSeconds(2));
+        second.ShouldBe(first);
+    }
+
+    [Fact]
+    public void GetDelay_WhenMultiplePagesOutcome_ResetsToMinimumInterval()
+    {
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(3));
+
+        _ = strategy.GetDelay(JobOutcome.None);
+        _ = strategy.GetDelay(JobOutcome.Failed(new InvalidOperationException("boom")));
+
+        var delay = strategy.GetDelay(JobOutcome.Succeeded(StorageQueuePollJobRunResult.MultiplePages));
+
+        delay.ShouldBe(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void GetDelay_WhenFailuresContinue_IncreasesDelayWithinExpectedRange()
+    {
+        var minimum = TimeSpan.FromSeconds(2);
+        var maximum = TimeSpan.FromSeconds(20);
+        var delta = TimeSpan.FromSeconds(3);
+        var strategy = new Strategy(minimum, maximum, delta);
+
+        var first = strategy.GetDelay(JobOutcome.None);
+        var second = strategy.GetDelay(JobOutcome.Failed(new InvalidOperationException("boom")));
+        var third = strategy.GetDelay(JobOutcome.Failed(new InvalidOperationException("boom")));
+
+        first.ShouldBe(minimum);
+        second.ShouldBeGreaterThanOrEqualTo(minimum + TimeSpan.FromSeconds(2.4));
+        second.ShouldBeLessThan(minimum + TimeSpan.FromSeconds(3.6));
+        third.ShouldBeGreaterThanOrEqualTo(minimum + TimeSpan.FromSeconds(4.8));
+        third.ShouldBeLessThan(minimum + TimeSpan.FromSeconds(7.2));
+    }
+
+    [Fact]
+    public void GetDelay_WhenSkipped_ReturnsTenMinutesAndSetsCurrentIntervalToMaximum()
+    {
+        var maximum = TimeSpan.FromSeconds(5);
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            maximum,
+            TimeSpan.FromSeconds(3));
+
+        _ = strategy.GetDelay(JobOutcome.None);
+
+        var skipped = strategy.GetDelay(JobOutcome.Skipped);
+        var afterSkippedFailure = strategy.GetDelay(JobOutcome.Failed(new InvalidOperationException("boom")));
+
+        skipped.ShouldBe(TimeSpan.FromMinutes(10));
+        afterSkippedFailure.ShouldBe(maximum);
+    }
+
+    [Fact]
+    public void GetDelay_WhenBackoffExceedsMaximum_ClampsToMaximumAndStaysThere()
+    {
+        var maximum = TimeSpan.FromSeconds(5);
+        var strategy = new Strategy(
+            TimeSpan.FromSeconds(2),
+            maximum,
+            TimeSpan.FromSeconds(10));
+
+        var first = strategy.GetDelay(JobOutcome.None);
+        var second = strategy.GetDelay(JobOutcome.Failed(new InvalidOperationException("boom")));
+        var third = strategy.GetDelay(JobOutcome.Disabled);
+
+        first.ShouldBe(TimeSpan.FromSeconds(2));
+        second.ShouldBe(maximum);
+        third.ShouldBe(maximum);
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueFactoryTests.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueFactoryTests.cs
@@ -1,0 +1,102 @@
+using Altinn.Authorization.ServiceDefaults.AzureIdentity;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fakes;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.TestHelpers;
+using Azure.Core;
+using Azure.Storage.Queues.Models;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests;
+
+public sealed class StorageQueueFactoryTests
+    : IAsyncLifetime
+{
+    private StorageFixture? _storage;
+
+    private StorageFixture Storage
+        => _storage ?? throw new InvalidOperationException("Storage fixture not initialized.");
+
+    [Fact]
+    public async Task CreateSender_CanSendMessage()
+    {
+        var queue = await Storage.CreateQueue();
+        var factory = CreateFactory(queue, expectedIdentityName: "sender-id");
+
+        var sender = factory.CreateSender("sender");
+
+        await sender.SendMessageAsync(new BinaryData("hello"), TestContext.Current.CancellationToken);
+
+        var client = Storage.CreateQueueClient(queue);
+        var received = await client.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        received.Value.Body.ToString().ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task CreateReceiver_CanMoveToPoisonQueue()
+    {
+        var queue = await Storage.CreateQueue();
+        var factory = CreateFactory(queue, expectedIdentityName: "receiver-id");
+
+        var senderClient = Storage.CreateQueueClient(queue);
+        await senderClient.SendMessageAsync("poison-me", cancellationToken: TestContext.Current.CancellationToken);
+
+        var receiver = factory.CreateReceiver("receiver");
+        var message = await ReceiveSingleMessage(receiver);
+
+        await receiver.MoveToPoisonQueueAsync(message, TestContext.Current.CancellationToken);
+
+        var queueReceived = await senderClient.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        queueReceived.Value.ShouldBeNull();
+
+        var poisonClient = Storage.CreatePoisonQueueClient(queue);
+        var poisonReceived = await poisonClient.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        poisonReceived.Value.ShouldNotBeNull();
+        poisonReceived.Value.Body.ToString().ShouldBe("poison-me");
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _storage = await TestContext.Current.GetFixture<StorageFixture>();
+    }
+
+    public ValueTask DisposeAsync()
+        => ValueTask.CompletedTask;
+
+    private StorageQueueFactory CreateFactory(StorageFixture.QueueInfo queue, string expectedIdentityName)
+    {
+        var credentialProvider = new TestTokenCredentialProvider(queue.Credential, expectedIdentityName);
+        var clientFactory = new TestStorageQueueClientFactory(Storage.CreateTransport());
+        var options = new TestOptionsMonitor<StorageQueueSettings>(name =>
+        {
+            name.ShouldBeOneOf("sender", "receiver");
+            return new StorageQueueSettings
+            {
+                IdentityName = expectedIdentityName,
+                StorageAccountUri = queue.StorageAccountUri,
+                QueueName = queue.QueueName,
+                PoisonQueueName = queue.PoisonQueueName,
+            };
+        });
+
+        return new StorageQueueFactory(credentialProvider, clientFactory, options);
+    }
+
+    private static async Task<QueueMessage> ReceiveSingleMessage(StorageQueueReceiver receiver)
+    {
+        await foreach (var batch in receiver.ReceiveAllMessageAsync(1, TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken))
+        {
+            return batch.ShouldHaveSingleItem();
+        }
+
+        throw new InvalidOperationException("Expected a message.");
+    }
+
+    private sealed class TestTokenCredentialProvider(TokenCredential credential, string expectedName)
+        : ITokenCredentialProvider
+    {
+        public TokenCredential GetCredential(string name)
+        {
+            name.ShouldBe(expectedName);
+            return credential;
+        }
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueuePollJobTests.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueuePollJobTests.cs
@@ -1,0 +1,130 @@
+using Altinn.Authorization.ServiceDefaults.Jobs;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests;
+
+public sealed class StorageQueuePollJobTests
+    : IAsyncLifetime
+{
+    private StorageFixture? _storage;
+
+    private StorageFixture Storage
+        => _storage ?? throw new InvalidOperationException("Storage fixture not initialized.");
+
+    [Fact]
+    public async Task RunAsync_WhenHandlerSucceeds_CompletesMessageAndReturnsSinglePage()
+    {
+        var queue = await Storage.CreateQueue();
+        var receiver = CreateReceiver(queue);
+        var processed = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddScoped<RecordingHandler>(_ => new RecordingHandler(processed));
+        await using var provider = services.BuildServiceProvider();
+
+        var job = new StorageQueuePollJob<RecordingHandler>(
+            receiver,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<StorageQueuePollJob<RecordingHandler>>.Instance);
+
+        var sender = Storage.CreateQueueClient(queue);
+        await sender.SendMessageAsync("payload", cancellationToken: TestContext.Current.CancellationToken);
+
+        var result = await ((IJob<StorageQueuePollJobRunResult>)job).RunAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(StorageQueuePollJobRunResult.SinglePage);
+        processed.ShouldBe(["payload"]);
+
+        var remaining = await sender.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        remaining.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenMessageHitsMaxRetries_MovesMessageToPoisonQueue()
+    {
+        var queue = await Storage.CreateQueue();
+        var mainClient = Storage.CreateQueueClient(queue);
+        var poisonClient = Storage.CreatePoisonQueueClient(queue);
+
+        await mainClient.SendMessageAsync("bad-message", cancellationToken: TestContext.Current.CancellationToken);
+        await BumpDequeueCountTo(queue, targetDequeueCount: 4);
+
+        var receiver = CreateReceiver(queue);
+        var services = new ServiceCollection();
+        services.AddScoped<AlwaysFailHandler>();
+        await using var provider = services.BuildServiceProvider();
+
+        var job = new StorageQueuePollJob<AlwaysFailHandler>(
+            receiver,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<StorageQueuePollJob<AlwaysFailHandler>>.Instance);
+
+        var result = await ((IJob<StorageQueuePollJobRunResult>)job).RunAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(StorageQueuePollJobRunResult.SinglePage);
+
+        var remaining = await mainClient.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        remaining.Value.ShouldBeNull();
+
+        var poisoned = await poisonClient.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        poisoned.Value.ShouldNotBeNull();
+        poisoned.Value.Body.ToString().ShouldBe("bad-message");
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _storage = await TestContext.Current.GetFixture<StorageFixture>();
+    }
+
+    public ValueTask DisposeAsync()
+        => ValueTask.CompletedTask;
+
+    private StorageQueueReceiver CreateReceiver(StorageFixture.QueueInfo queue)
+        => new(Storage.CreateQueueClient(queue), Storage.CreatePoisonQueueClient(queue));
+
+    private async Task BumpDequeueCountTo(StorageFixture.QueueInfo queue, int targetDequeueCount)
+    {
+        var client = Storage.CreateQueueClient(queue);
+
+        for (var expected = 1; expected <= targetDequeueCount; expected++)
+        {
+            var received = await client.ReceiveMessageAsync(
+                visibilityTimeout: TimeSpan.FromSeconds(10),
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            received.Value.ShouldNotBeNull();
+            received.Value.DequeueCount.ShouldBe(expected);
+
+            await client.UpdateMessageAsync(
+                messageId: received.Value.MessageId,
+                popReceipt: received.Value.PopReceipt,
+                visibilityTimeout: TimeSpan.Zero,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            if (expected < targetDequeueCount)
+            {
+                continue;
+            }
+        }
+    }
+
+    private sealed class RecordingHandler(List<string> processedMessages)
+        : IStorageQueueMessageHandler
+    {
+        public Task HandleMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+        {
+            processedMessages.Add(message.Body.ToString());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AlwaysFailHandler
+        : IStorageQueueMessageHandler
+    {
+        public Task HandleMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+            => Task.FromException(new InvalidOperationException("boom"));
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueSenderTests.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueueSenderTests.cs
@@ -1,0 +1,40 @@
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests;
+
+public sealed class StorageQueueSenderTests
+    : IAsyncLifetime
+{
+    private StorageFixture? _storage;
+
+    private CancellationToken CancellationToken
+        => TestContext.Current.CancellationToken;
+
+    private StorageFixture Storage
+        => _storage ?? throw new InvalidOperationException("Storage fixture not initialized.");
+
+    [Fact]
+    public async Task CanSendMessage()
+    {
+        var queue = await Storage.CreateQueue();
+        var client = Storage.CreateQueueClient(queue);
+
+        var sender = new StorageQueueSender(client);
+
+        var message = new BinaryData("Hello, world!");
+        await sender.SendMessageAsync(message, CancellationToken);
+
+        // Verify
+        var received = await client.ReceiveMessageAsync(cancellationToken: CancellationToken);
+        received.Value.ShouldNotBeNull();
+        received.Value.Body.ToString().ShouldBe("Hello, world!");
+    }
+
+    public ValueTask DisposeAsync()
+        => ValueTask.CompletedTask;
+
+    public async ValueTask InitializeAsync()
+    {
+        _storage = await TestContext.Current.GetFixture<StorageFixture>();
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueuesServiceCollectionExtensionsTests.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/StorageQueuesServiceCollectionExtensionsTests.cs
@@ -1,0 +1,106 @@
+using Altinn.Authorization.ServiceDefaults.AzureIdentity;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fakes;
+using Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.Fixtures;
+using Azure.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests;
+
+public sealed class StorageQueuesServiceCollectionExtensionsTests
+    : IAsyncLifetime
+{
+    private StorageFixture? _storage;
+
+    private StorageFixture Storage
+        => _storage ?? throw new InvalidOperationException("Storage fixture not initialized.");
+
+    [Fact]
+    public void AddStorageQueue_RegistersCoreServicesOnce()
+    {
+        var services = new ServiceCollection();
+
+        services.AddStorageQueue("queue-a");
+        services.AddStorageQueue("queue-b");
+
+        services.Count(static d => d.ServiceType == typeof(IStorageQueueClientFactory)).ShouldBe(1);
+        services.Count(static d => d.ServiceType == typeof(IStorageQueueMessageSenderFactory)).ShouldBe(1);
+        services.Count(static d => d.ServiceType == typeof(StorageQueueFactory)).ShouldBe(1);
+        services.Count(static d => d.ServiceType == typeof(ITokenCredentialProvider)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task AddStorageQueue_CanCreateNamedSender()
+    {
+        var queue = await Storage.CreateQueue();
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        services.AddSingleton<IConfiguration>(configuration);
+
+        services.AddStorageQueue("test")
+            .Configure(options =>
+            {
+                options.IdentityName = "test";
+                options.StorageAccountUri = queue.StorageAccountUri;
+                options.QueueName = queue.QueueName;
+                options.PoisonQueueName = queue.PoisonQueueName;
+            });
+        services.AddSingleton<ITokenCredentialProvider>(new TestTokenCredentialProvider(queue.Credential));
+        services.AddSingleton<IStorageQueueClientFactory>(new TestStorageQueueClientFactory(Storage.CreateTransport()));
+
+        await using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IStorageQueueMessageSenderFactory>();
+        var sender = factory.CreateSender("test");
+
+        await sender.SendMessageAsync(new BinaryData("from-factory"), TestContext.Current.CancellationToken);
+
+        var client = Storage.CreateQueueClient(queue);
+        var received = await client.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken);
+        received.Value.Body.ToString().ShouldBe("from-factory");
+    }
+
+    [Fact]
+    public void AddStorageQueueJob_RegistersHandlerAsScoped()
+    {
+        var services = new ServiceCollection();
+
+        services.AddStorageQueueJob<TestMessageHandler>("test", settings =>
+        {
+            settings.MinimumInterval = TimeSpan.FromMilliseconds(50);
+            settings.MaximumInterval = TimeSpan.FromSeconds(1);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<TestMessageHandler>().ShouldNotBeNull();
+        services.Any(static d => d.ServiceType == typeof(TestMessageHandler) && d.Lifetime == ServiceLifetime.Scoped).ShouldBeTrue();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _storage = await TestContext.Current.GetFixture<StorageFixture>();
+    }
+
+    public ValueTask DisposeAsync()
+        => ValueTask.CompletedTask;
+
+    private sealed class TestTokenCredentialProvider(TokenCredential credential)
+        : ITokenCredentialProvider
+    {
+        public TokenCredential GetCredential(string name)
+        {
+            name.ShouldBe("test");
+            return credential;
+        }
+    }
+
+    private sealed class TestMessageHandler
+        : IStorageQueueMessageHandler
+    {
+        public Task HandleMessageAsync(Azure.Storage.Queues.Models.QueueMessage message, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/TestHelpers/TestOptionsMonitor.cs
+++ b/src/apps/Altinn.Register/test/ServiceDefaults.StorageQueues.Tests/TestHelpers/TestOptionsMonitor.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Options;
+
+namespace Altinn.Authorization.ServiceDefaults.StorageQueues.Tests.TestHelpers;
+
+internal sealed class TestOptionsMonitor<TOptions>(Func<string, TOptions> get)
+    : IOptionsMonitor<TOptions>
+{
+    public TOptions CurrentValue => Get(Options.DefaultName);
+
+    public TOptions Get(string? name)
+        => get(name ?? Options.DefaultName);
+
+    public IDisposable? OnChange(Action<TOptions, string?> listener)
+        => null;
+}


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #899
- <kbd>&nbsp;2&nbsp;</kbd> #896 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #895
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Storage Queue support: senders, receivers, polling jobs, configurable schedules, and named queue settings with validation
  * Built-in retry with randomized exponential backoff and poison-queue handling for failed messages

* **Chores**
  * Centralized package version updates and added queue/storage test tooling

* **Tests**
  * Comprehensive unit/integration tests for factory, sender/receiver, polling job, and backoff strategy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->