### PR TITLE
RT and KT samendring are no-op instead of default errors

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.Xml/CcrXmlProcessor.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.Xml/CcrXmlProcessor.cs
@@ -874,13 +874,18 @@ internal sealed class CcrXmlProcessor
                 }
 
             case ("S", _) when endringstype == "N" || endringstype == "U":
+            case ("R", "T") when endringstype == "N" || endringstype == "U":
+            case ("K", "T") when endringstype == "N" || endringstype == "U":
                 {
-                    // We currently do not have a mapping for samendringsfritekst, whether new, update or delete.
+                    // Free-text samendring/role/connection entries are supplementary descriptive
+                    // text only - the structured ("R", "D") / ("K", "D") siblings (when present)
+                    // carry the actual role-assignment data. We currently have no mapping for any
+                    // samendringsfritekst variant, whether new, update or delete.
                     break;
                 }
 
             default:
-                ThrowHelper.ThrowArgumentException($"XmlReader: unknown samendring type '{type}' (date = '{data}') in <samendringer> element.");
+                ThrowHelper.ThrowArgumentException($"XmlReader: unknown samendring '{felttype}' type '{type}' (data = '{data}') in <samendringer> element.");
                 return; // unreachable
         }
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario26A.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario26A.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics.CodeAnalysis;
+using Altinn.Register.Core.Parties;
+using Altinn.Register.Core.Parties.Records;
+using Altinn.Register.Core.UnitOfWork;
+using Altinn.Register.TestUtils.TestData;
+
+namespace Altinn.Register.IntegrationTests.Ccr.Xml;
+
+/// <summary>
+/// Regression test for <c>&lt;samendringer data="T" type="R"&gt;</c> and
+/// <c>&lt;samendringer data="T" type="K"&gt;</c> elements — supplementary free-text role and
+/// connection entries that previously caused <c>CcrXmlProcessor</c> to throw
+/// <c>"unknown samendring type ..."</c>. They should now be consumed silently while structured
+/// <c>data="D"</c> siblings continue to apply normally.
+/// </summary>
+public class Scenario26A
+    : CcrXmlUpdateTestBase
+{
+    private OrganizationRecord _org = null!;
+    private PersonRecord _personSife = null!;
+
+    protected override async ValueTask Setup(IUnitOfWork uow, CancellationToken cancellationToken)
+    {
+        _org = await uow.CreateOrg(
+            unitType: "FLI",
+            name: "FRITEKST SAMENDRING TEST",
+            cancellationToken: cancellationToken);
+
+        _personSife = await uow.CreatePerson(
+            name: PersonName.Create("Rik", "Kveld"),
+            cancellationToken: cancellationToken);
+    }
+
+    [StringSyntax(StringSyntaxAttribute.Xml)]
+    protected override string XmlToApply
+        => $$"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <batchAjourholdXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="batchAjourholdXML_versjon2_1.xsd">
+          <head avsender="ER" dato="20260530" kjoerenr="04990" mottaker="ALT" type="A" />
+          <enhet organisasjonsnummer="{{_org.OrganizationIdentifier.Value}}" organisasjonsform="FLI" hovedsakstype="N" undersakstype="NY" foersteOverfoering="J" datoFoedt="20260530" datoSistEndret="20260530">
+            <infotype felttype="NAVN" endringstype="N">
+              <navn1>FRITEKST SAMENDRING TEST</navn1>
+              <rednavn>FRITEKST SAMENDRING TEST</rednavn>
+            </infotype>
+            <samendringer data="D" felttype="SIFE" endringstype="N" type="R">
+              <rolleFratraadt>N</rolleFratraadt>
+              <rolleRekkefoelge>1</rolleRekkefoelge>
+              <rolleFoedselsnr>{{_personSife.PersonIdentifier.Value}}</rolleFoedselsnr>
+              <fornavn>Rik</fornavn>
+              <slektsnavn>Kveld</slektsnavn>
+              <personstatus>L</personstatus>
+            </samendringer>
+            <samendringer data="T" felttype="SIFE" endringstype="N" type="R">
+              <rollefritFoedselsnr>{{_personSife.PersonIdentifier.Value}}</rollefritFoedselsnr>
+              <rollefritTekstlinje>to av ovennevnte i fellesskap.</rollefritTekstlinje>
+            </samendringer>
+          </enhet>
+          <trai antallEnheter="1" avsender="ER" />
+        </batchAjourholdXML>
+        """;
+
+    protected override async ValueTask Verify(IUnitOfWork uow, CancellationToken cancellationToken)
+    {
+        var parties = uow.GetPartyPersistence();
+        var roles = uow.GetPartyExternalRolePersistence();
+
+        var updatedOrg = await parties
+            .GetOrganizationByIdentifier(_org.OrganizationIdentifier.Value!, PartyFieldIncludes.Party | PartyFieldIncludes.Organization, cancellationToken)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        updatedOrg.ShouldNotBeNull();
+
+        // The free-text role/connection samendringer should not introduce any extra
+        // assignments. The structured SIFE sibling should be the only one applied.
+        var roleAssignments = await roles
+            .GetExternalRoleAssignmentsFromParty(partyUuid: _org.PartyUuid.Value, cancellationToken: cancellationToken)
+            .ToListAsync(cancellationToken);
+
+        roleAssignments.Count.ShouldBe(1);
+        var sife = roleAssignments.ShouldHaveSingleItem();
+        sife.Identifier.ShouldBe("signerer-fellesskap");
+        sife.ToParty.ShouldBe(_personSife.PartyUuid.Value);
+
+        updatedOrg.DisplayName.Value.ShouldBe("FRITEKST SAMENDRING TEST");
+    }
+}

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario26A.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario26A.cs
@@ -7,11 +7,11 @@ using Altinn.Register.TestUtils.TestData;
 namespace Altinn.Register.IntegrationTests.Ccr.Xml;
 
 /// <summary>
-/// Regression test for <c>&lt;samendringer data="T" type="R"&gt;</c> and
-/// <c>&lt;samendringer data="T" type="K"&gt;</c> elements — supplementary free-text role and
-/// connection entries that previously caused <c>CcrXmlProcessor</c> to throw
-/// <c>"unknown samendring type ..."</c>. They should now be consumed silently while structured
-/// <c>data="D"</c> siblings continue to apply normally.
+/// Regression test for <c>&lt;samendringer data="T" type="R"&gt;</c> — supplementary free-text
+/// role entries that previously caused <c>CcrXmlProcessor</c> to throw
+/// <c>"unknown samendring type ..."</c>. The element should now be consumed silently while the
+/// structured <c>data="D"</c> sibling continues to apply normally. Free-text connection
+/// (<c>type="K"</c>) coverage lives in a separate scenario.
 /// </summary>
 public class Scenario26A
     : CcrXmlUpdateTestBase

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario27A.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/Scenario27A.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics.CodeAnalysis;
+using Altinn.Register.Core.Parties;
+using Altinn.Register.Core.Parties.Records;
+using Altinn.Register.Core.UnitOfWork;
+using Altinn.Register.TestUtils.TestData;
+
+namespace Altinn.Register.IntegrationTests.Ccr.Xml;
+
+/// <summary>
+/// Regression test for <c>&lt;samendringer data="T" type="K"&gt;</c> — supplementary free-text
+/// connection entries that previously caused <c>CcrXmlProcessor</c> to throw
+/// <c>"unknown samendring type ..."</c>. The element should now be consumed silently with no
+/// effect on persisted role assignments or the organization itself. Free-text role
+/// (<c>type="R"</c>) coverage lives in a separate scenario.
+/// </summary>
+public class Scenario27A
+    : CcrXmlUpdateTestBase
+{
+    private OrganizationRecord _org = null!;
+
+    protected override async ValueTask Setup(IUnitOfWork uow, CancellationToken cancellationToken)
+    {
+        _org = await uow.CreateOrg(
+            unitType: "FLI",
+            name: "FRITEKST KNYTNING TEST",
+            cancellationToken: cancellationToken);
+    }
+
+    [StringSyntax(StringSyntaxAttribute.Xml)]
+    protected override string XmlToApply
+        => $$"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <batchAjourholdXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="batchAjourholdXML_versjon2_1.xsd">
+          <head avsender="ER" dato="20260530" kjoerenr="04991" mottaker="ALT" type="A" />
+          <enhet organisasjonsnummer="{{_org.OrganizationIdentifier.Value}}" organisasjonsform="FLI" hovedsakstype="N" undersakstype="NY" foersteOverfoering="J" datoFoedt="20260530" datoSistEndret="20260530">
+            <infotype felttype="NAVN" endringstype="N">
+              <navn1>FRITEKST KNYTNING TEST</navn1>
+              <rednavn>FRITEKST KNYTNING TEST</rednavn>
+            </infotype>
+            <samendringer data="T" felttype="KONT" endringstype="N" type="K">
+              <knytningfritOrganisasjonsnummer>999888777</knytningfritOrganisasjonsnummer>
+              <knytningfritTekstlinje>kontaktperson via annet selskap.</knytningfritTekstlinje>
+            </samendringer>
+          </enhet>
+          <trai antallEnheter="1" avsender="ER" />
+        </batchAjourholdXML>
+        """;
+
+    protected override async ValueTask Verify(IUnitOfWork uow, CancellationToken cancellationToken)
+    {
+        var parties = uow.GetPartyPersistence();
+        var roles = uow.GetPartyExternalRolePersistence();
+
+        var updatedOrg = await parties
+            .GetOrganizationByIdentifier(_org.OrganizationIdentifier.Value!, PartyFieldIncludes.Party | PartyFieldIncludes.Organization, cancellationToken)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        updatedOrg.ShouldNotBeNull();
+        updatedOrg.DisplayName.Value.ShouldBe("FRITEKST KNYTNING TEST");
+
+        // The free-text connection samendring is supplementary text only - no structured K/R
+        // siblings are present, so no role assignments should exist for this org. Crucially,
+        // the fake knytningfritOrganisasjonsnummer above (999888777) is NOT looked up: if it
+        // were, the import would fail because that org doesn't exist in the test DB.
+        var roleAssignments = await roles
+            .GetExternalRoleAssignmentsFromParty(partyUuid: _org.PartyUuid.Value, cancellationToken: cancellationToken)
+            .ToListAsync(cancellationToken);
+
+        roleAssignments.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain free-text data patterns in CCR XML processing to prevent creation of unnecessary role assignments while maintaining structured data processing. Enhanced error reporting for invalid data patterns.

* **Tests**
  * Added regression test validating correct behavior for complex role assignment scenarios in XML data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->