### PR TITLE
chore: lowercase idporten emails

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetOrCreateSelfIdentifiedUser.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetOrCreateSelfIdentifiedUser.cs
@@ -172,7 +172,7 @@ internal sealed partial class GetOrCreateSelfIdentifiedUserFromBridgeHandler(
         {
             externalIdentity = PartyExternalRefUrn.IDPortenEmail.Create(UrnEncoded.Create(emailRequest.Email)).ToString();
             userName = $"email:{emailRequest.Email}";
-            email = emailRequest.Email;
+            email = emailRequest.Email.ToLowerInvariant();
         }
         else if (request.TryGetValue(out GetOrCreateSelfIdentifiedEduUserRequest eduRequest))
         {
@@ -373,7 +373,7 @@ internal sealed class GetOrCreateSelfIdentifiedUserFromDBHandler(IUnitOfWorkMana
             cancellationToken: cancellationToken);
 
         var parties = uow.GetPartyPersistence();
-        var result = await parties.GetOrCreateSelfIdentifiedEmailUser(request.Email, cancellationToken);
+        var result = await parties.GetOrCreateSelfIdentifiedEmailUser(request.Email.ToLowerInvariant(), cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.61-enforce-lowercase-idporten-email/00-self-identified-user-email.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.61-enforce-lowercase-idporten-email/00-self-identified-user-email.sql
@@ -1,0 +1,12 @@
+UPDATE register.self_identified_user
+SET email = lower(email)
+WHERE email IS NOT NULL
+  AND email COLLATE "default" <> lower(email) COLLATE "default";
+
+ALTER TABLE register.self_identified_user
+  ALTER COLUMN email TYPE text COLLATE "default";
+
+ALTER TABLE register.self_identified_user
+  ADD CONSTRAINT chk_si_email_lowercase CHECK (
+    email IS NULL OR email = lower(email)
+  );

--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.UpsertPartyQuery.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/PostgreSqlPartyPersistence.UpsertPartyQuery.cs
@@ -241,6 +241,7 @@ internal partial class PostgreSqlPartyPersistence
                     @email)
                 """;
 
+            Debug.Assert(string.Equals(email.ToLowerInvariant(), email, StringComparison.Ordinal));
             await using var cmd = connection.CreateCommand(QUERY);
 
             cmd.Parameters.Add<PersistenceFeatureFlag[]>("flags").TypedValue = flags;

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Validation/PartyForImportValidator.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Validation/PartyForImportValidator.cs
@@ -136,6 +136,12 @@ public readonly struct PartyForImportValidator
                 case SelfIdentifiedUserType.IdPortenEmail:
                     CheckRequired(ref context, input.Email.HasValue, "/email");
                     CheckNull(ref context, input.ExtRef, "/extRef");
+
+                    if (input.Email.HasValue)
+                    {
+                        Check(ref context, string.Equals(input.Email.Value.ToLowerInvariant(), input.Email.Value), ValidationErrors.InvalidValue, "/email", detail: "Email must be lowercase");
+                    }
+
                     break;
 
                 case SelfIdentifiedUserType.Educational:
@@ -281,11 +287,11 @@ public readonly struct PartyForImportValidator
         }
     }
 
-    private static void Check(ref ValidationContext context, bool condition, ValidationErrorDescriptor descriptor, string path)
+    private static void Check(ref ValidationContext context, bool condition, ValidationErrorDescriptor descriptor, string path, string? detail = null)
     {
         if (!condition)
         {
-            context.AddChildProblem(descriptor, path);
+            context.AddChildProblem(descriptor, path, detail);
         }
     }
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/UsersControllerTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/UsersControllerTests.cs
@@ -5,9 +5,12 @@ using Altinn.Authorization.TestUtils.Http;
 using Altinn.Register.Contracts;
 using Altinn.Register.Core.A2.SblProfile;
 using Altinn.Register.Core.Errors;
+using Altinn.Register.Core.Parties;
 using Altinn.Register.Core.Parties.Records;
+using Altinn.Register.Core.UnitOfWork;
 using Altinn.Register.Models;
 using Altinn.Register.TestUtils.TestData;
+using Altinn.Urn;
 
 namespace Altinn.Register.IntegrationTests.Controllers;
 
@@ -179,6 +182,44 @@ public class UsersControllerTests
         body.SelfIdentifiedUserType.Value.Value.ShouldBe(SelfIdentifiedUserType.IdPortenEmail);
         body.Email.Value.ShouldBe(Email);
         body.ExternalUrn.IsNull.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetOrCreate_IdPortenEmail_LookupMiss_WithUppercaseEmail_StoresLowercaseEmailAndExternalUrn()
+    {
+        const string UppercaseEmail = "UPPER@example.com";
+        const string LowercaseEmail = "upper@example.com";
+        var expectedExternalUrn = PartyExternalRefUrn.IDPortenEmail.Create(UrnEncoded.Create(LowercaseEmail));
+
+        ExpectAccessManagementSelfIdentifiedUserCreate();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, EndpointUrl)
+            .WithPlatformToken("unittest");
+        request.Content = JsonContent.Create(new SelfIdentifiedUserCreateRequest
+        {
+            SelfIdentifiedUserType = SelfIdentifiedUserType.IdPortenEmail,
+            ExternalIdentity = expectedExternalUrn.ToString(),
+            UserName = $"epost:{LowercaseEmail}",
+            Email = UppercaseEmail,
+        });
+
+        var response = await HttpClient.SendAsync(request, TestContext.Current.CancellationToken);
+
+        await response.ShouldHaveStatusCode(HttpStatusCode.OK);
+        var body = await response.ShouldHaveJsonContent<SelfIdentifiedUser>();
+
+        body.ShouldNotBeNull();
+        body.Email.Value.ShouldBe(LowercaseEmail);
+        body.ExternalUrn.Value.ShouldBe(expectedExternalUrn);
+
+        var stored = await Check(async (uow, ct) =>
+            await uow.GetPartyPersistence()
+                .GetPartyById(body.Uuid, PartyFieldIncludes.Party | PartyFieldIncludes.SelfIdentifiedUser, ct)
+                .FirstAsync(ct));
+
+        var storedSelfIdentifiedUser = stored.ShouldBeOfType<SelfIdentifiedUserRecord>();
+        storedSelfIdentifiedUser.Email.Value.ShouldBe(LowercaseEmail);
+        storedSelfIdentifiedUser.ExternalUrn.Value.ShouldBe(expectedExternalUrn);
     }
 
     [Fact]

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/PartyImport/Ccr/CcrImportJobTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/PartyImport/Ccr/CcrImportJobTests.cs
@@ -77,10 +77,10 @@ public class CcrImportJobTests
         foreach (var orgNumber in orgIdentifiers)
         {
             var conversation = await TestHarness.Conversation<ImportCcrXmlCommand>(cmd => cmd.OrganizationIdentifier == OrganizationIdentifier.Parse(orgNumber), CancellationToken);
-            conversation.ShouldNotBeNull();
+            conversation.ShouldNotBeNull(customMessage: $"there should be a conversation for organization {orgNumber}");
 
             var completedEvent = await conversation.Events.OfType<CcrXmlImportCompletedEvent>().FirstOrDefaultAsync(CancellationToken);
-            var command = await conversation.Commands.Completed.OfType<ImportCcrXmlCommand>().FirstOrDefaultAsync(CancellationToken);
+            var command = await conversation.Commands.OfType<ImportCcrXmlCommand>().FirstOrDefaultAsync(CancellationToken);
             command.ShouldNotBeNull();
             command.BatchId.ShouldBe(1U);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email addresses for self-identified users are now normalized to lowercase for consistent lookup, storage, and derived fields (such as External URN).
  * Added database enforcement to ensure the stored email is either NULL or already lowercase.
  * Strengthened import validation to reject/flag non-lowercase Id Porten email values when provided.

* **Tests**
  * Added an integration test verifying that uppercase emails are stored as lowercase and that External URN matches the normalized value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->