### PR TITLE
feat: send online updates to queue

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -140,4 +140,33 @@
     <Error Condition="'$(Version)' == ''" Text="Version not defined in '$(VersionFilePath)'" />
   </Target>
 
+  <Target Name="_PatchTestAppHostForDevenvDotNet"
+    AfterTargets="_CreateAppHost"
+    Condition="
+      '$(IsTestProject)' == 'true'
+      And '$(UseAppHost)' == 'true'
+      And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+      And Exists('$(MSBuildThisFileDirectory).devenv/profile/share/dotnet')
+      And Exists('@(IntermediateAssembly)')
+      And Exists('$(AppHostSourcePath)')
+    ">
+    <PropertyGroup>
+      <_DevenvDotNetRoot>$(MSBuildThisFileDirectory).devenv/profile/share/dotnet</_DevenvDotNetRoot>
+      <_DevenvDotNetRootRelativeToTargetDir>$([MSBuild]::MakeRelative('$(TargetDir)',
+        '$(_DevenvDotNetRoot)'))</_DevenvDotNetRootRelativeToTargetDir>
+    </PropertyGroup>
+
+    <CreateAppHost AppHostSourcePath="$(AppHostSourcePath)"
+      AppHostDestinationPath="$(AppHostIntermediatePath)"
+      AppBinaryName="$(AssemblyName)$(TargetExt)"
+      IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')"
+      WindowsGraphicalUserInterface="$(_UseWindowsGraphicalUserInterface)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      EnableMacOSCodeSign="$(_EnableMacOSCodeSign)"
+      DisableCetCompat="$(_DisableCetCompat)"
+      DotNetSearchLocations="AppRelative"
+      AppRelativeDotNet="$(_DevenvDotNetRootRelativeToTargetDir)" />
+  </Target>
+
 </Project>

--- a/src/apps/Altinn.Register/src/Altinn.Register/Controllers/CcrController.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/Controllers/CcrController.cs
@@ -9,12 +9,14 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml;
 using Altinn.Authorization.ModelUtils.EnumUtils;
+using Altinn.Authorization.ServiceDefaults.MassTransit;
 using Altinn.Register.Conventions;
 using Altinn.Register.Core;
 using Altinn.Register.Core.Ccr;
 using Altinn.Register.Core.CcrLog;
 using Altinn.Register.Core.Utils;
 using Altinn.Register.Integrations.Ccr.Xml;
+using Altinn.Register.PartyImport.Ccr;
 using Asp.Versioning;
 using CommunityToolkit.Diagnostics;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -185,6 +187,7 @@ public partial class CcrController
             writer.Flush();
         }
 
+        var sender = HttpContext.RequestServices.GetRequiredService<ICommandSender>();
         var ccrService = HttpContext.RequestServices.GetRequiredService<CcrService>();
         if (HttpContext.Connection.RemoteIpAddress is null
             || string.IsNullOrWhiteSpace(result.UserName)
@@ -197,11 +200,16 @@ public partial class CcrController
 
         try
         {
-            await ccrService.UpdateFromCcr(
-                commandId: Guid.CreateVersion7(),
-                seq.AsReadOnlySequence,
-                federate: federate,
-                cancellationToken);
+            var command = new ImportCcrXmlCommand
+            {
+                BatchId = null,
+                OrganizationIdentifier = null,
+                Document = seq.AsReadOnlySequence.ToArray(),
+                Federate = federate,
+            };
+
+            await sender.Send(command, cancellationToken);
+            Response.Headers.Append("X-Altinn-Register-Ccr-CommandId", command.CommandId.ToString("D"));
         }
         catch
         {

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Ccr/ImportCcrPartyConsumer.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Ccr/ImportCcrPartyConsumer.cs
@@ -38,12 +38,19 @@ public sealed partial class ImportCcrXmlConsumer
     {
         var message = context.Message;
 
-        Log.ConsumingCcrUpdate(_logger, message.OrganizationIdentifier);
+        if (message.OrganizationIdentifier is { } orgId)
+        {
+            Log.ConsumingCcrUpdate(_logger, orgId);
+        }
+        else
+        {
+            Log.ConsumingCcrUpdateWithoutOrganizationIdentifier(_logger);
+        }
 
         var result = await _ccrService.UpdateFromCcr(
             commandId: message.CommandId,
             input: new ReadOnlySequence<byte>(message.Document),
-            federate: true,
+            federate: message.Federate ?? true,
             cancellationToken: context.CancellationToken);
 
         await context.PublishBatch(
@@ -103,5 +110,8 @@ public sealed partial class ImportCcrXmlConsumer
     {
         [LoggerMessage(0, LogLevel.Information, "Consuming CCR update for organization {OrganizationIdentifier}.")]
         public static partial void ConsumingCcrUpdate(ILogger logger, OrganizationIdentifier organizationIdentifier);
+
+        [LoggerMessage(1, LogLevel.Information, "Consuming CCR update without organization identifier.")]
+        public static partial void ConsumingCcrUpdateWithoutOrganizationIdentifier(ILogger logger);
     }
 }

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Ccr/ImportCcrXmlCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/Ccr/ImportCcrXmlCommand.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Altinn.Authorization.ServiceDefaults.MassTransit;
 using Altinn.Register.Contracts;
 
@@ -14,15 +15,27 @@ public sealed record ImportCcrXmlCommand
     /// Gets the unique identifier of the batch, if available.
     /// Is null for sync SOAP requests, but will be set for messages produced by the <see cref="CcrImportJob"/>.
     /// </summary>
-    public required uint? BatchId { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public uint? BatchId { get; init; }
 
     /// <summary>
     /// Gets the identifier of the organization this command pertains to.
+    /// Is null for sync SOAP requests, but will be set for messages produced by the <see cref="CcrImportJob"/>.
     /// </summary>
-    public required OrganizationIdentifier OrganizationIdentifier { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public OrganizationIdentifier? OrganizationIdentifier { get; init; }
 
     /// <summary>
     /// Gets the CCR XML document as raw bytes.
     /// </summary>
     public required byte[] Document { get; init; }
+
+    /// <summary>
+    /// Gets whether the update should be federated to other Altinn instances.
+    /// </summary>
+    /// <remarks>
+    /// If <see langword="null"/>, the default behavior is to federate the update.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Federate { get; init; }
 }

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/CcrXmlUpdateTestBase.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Ccr/Xml/CcrXmlUpdateTestBase.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Xml;
 using Altinn.Register.Core.Ccr;
 using Altinn.Register.Core.UnitOfWork;
+using Altinn.Register.PartyImport.Ccr;
+using Altinn.Register.TestUtils.MassTransit;
 
 namespace Altinn.Register.IntegrationTests.Ccr.Xml;
 
@@ -70,6 +72,14 @@ public abstract class CcrXmlUpdateTestBase
 
         using var response = await HttpClient.SendAsync(request, CancellationToken);
         response.EnsureSuccessStatusCode();
+
+        response.Headers.TryGetValues("X-Altinn-Register-Ccr-CommandId", out var values).ShouldBeTrue();
+        var value = values.ShouldHaveSingleItem();
+        Guid.TryParse(value, out var commandId).ShouldBeTrue();
+
+        var conversation = await TestHarness.Conversation<ImportCcrXmlCommand>(cmd => cmd.CommandId == commandId, CancellationToken);
+        var completedEvent = await conversation.Events.OfType<CcrXmlImportCompletedEvent>().FirstOrDefaultAsync(CancellationToken);
+        completedEvent.ShouldNotBeNull();
 
         await Check(async (uow, ct) =>
         {

--- a/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/MassTransit/TestHarnessConversation.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/MassTransit/TestHarnessConversation.cs
@@ -32,22 +32,22 @@ public sealed class TestHarnessConversation
     /// </summary>
     public AsyncMessageList<EventBase, IPublishedMessage<EventBase>> Events
         => new AsyncMessageList<EventBase, IPublishedMessage<EventBase>, IPublishedMessage>(
-            _harness,
-            (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
-            _harness.Published,
-            (IPublishedMessage m) => m.Context.ConversationId == _conversationId,
-            static m => m.Context.Message,
-            _cancellationToken);
+            harness: _harness,
+            faultFilter: (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
+            source: _harness.Published,
+            filter: (IPublishedMessage m) => m.Context.ConversationId == _conversationId,
+            selector: static m => m.Context.Message,
+            cancellationToken: _cancellationToken);
 
     /// <summary>
     /// Gets the commands in the conversation.
     /// </summary>
     public AsyncMessageList<CommandBase, IReceivedMessage<CommandBase>> Commands
         => new AsyncMessageList<CommandBase, IReceivedMessage<CommandBase>, IReceivedMessage>(
-            _harness,
-            (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
-            _harness.Consumed,
-            (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
-            static m => m.Context.Message,
-            _cancellationToken);
+            harness: _harness,
+            faultFilter: (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
+            source: _harness.Consumed,
+            filter: (IReceivedMessage m) => m.Context.ConversationId == _conversationId,
+            selector: static m => m.Context.Message,
+            cancellationToken: _cancellationToken);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CCR online updates now return a command ID in the response header, making it easier to track submitted imports.
  * CCR updates now support requests without an organization identifier and optional federation settings.

* **Bug Fixes**
  * Improved handling of CCR import flow so updates are routed more consistently and completed events are emitted after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->