### PR TITLE
fix: do not use dates from the system-user registry as created/modified at

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/SystemUser/SystemUserImportJob.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/SystemUser/SystemUserImportJob.cs
@@ -144,6 +144,7 @@ internal sealed partial class SystemUserImportJob
                     continue;
                 }
 
+                var now = _timeProvider.GetUtcNow();
                 var party = new SystemUserRecord
                 {
                     PartyUuid = systemUser.Id,
@@ -153,12 +154,12 @@ internal sealed partial class SystemUserImportJob
                     DisplayName = systemUser.Name,
                     PersonIdentifier = FieldValue.Null,
                     OrganizationIdentifier = FieldValue.Null,
-                    CreatedAt = systemUser.CreatedAt,
-                    ModifiedAt = systemUser.LastChangedAt,
+                    CreatedAt = now,
+                    ModifiedAt = now,
                     UserIds = FieldValue.Unset,
                     Usernames = FieldValue.Unset,
                     IsDeleted = systemUser.IsDeleted,
-                    DeletedAt = systemUser.IsDeleted ? systemUser.LastChangedAt : FieldValue.Null,
+                    DeletedAt = systemUser.IsDeleted ? now : FieldValue.Null,
                     VersionId = FieldValue.Unset,
                     SystemUserType = systemUser.Type.Value,
                 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in imported system user timestamps.
  * New and updated records now use the current import time for created and modified fields.
  * Deleted records now get a matching deletion timestamp when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->