### PR TITLE
fix: ignored CCR information

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.FileImport/CcrFlatFileProcessor.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.FileImport/CcrFlatFileProcessor.cs
@@ -611,6 +611,7 @@ internal sealed partial class CcrFlatFileProcessor
                 /////////////////////////////////////////////////////////////////////////////
                 // ignorerte noder
                 case "MANR": // Matrikkeladresse
+                case "R-FS": // Utgått infotype
                     {
                         // not in use, ignored
                         break;

--- a/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.Xml/CcrXmlProcessor.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Integrations.Ccr.Xml/CcrXmlProcessor.cs
@@ -422,6 +422,7 @@ internal sealed class CcrXmlProcessor
             case ("R-FV", _):
             case ("R-MV", _):
             case ("R-SR", _):
+            case ("R-FS", _):
             case ("RSKP", _):
             case ("RVFG", _):
             case ("SLFR", _):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated record handling to safely ignore an obsolete record type during import and XML parsing.
  * Prevented imports from failing when this legacy record appears; it is now skipped instead of treated as an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->