### PR TITLE
fix: retry without A2

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportNprPartyCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportNprPartyCommand.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Altinn.Authorization.ModelUtils;
 using Altinn.Register.Contracts;
 using Altinn.Register.Core.Parties.Records;
@@ -20,11 +19,12 @@ public partial class A2PartyImportSaga
 
     /// <inheritdoc/>
     public async Task Handle(ImportNprPartyCommand message, CancellationToken cancellationToken)
+        => await HandleImportNprParty(message.PersonIdentifier, cancellationToken);
+
+    private async Task HandleImportNprParty(PersonIdentifier personIdentifier, CancellationToken cancellationToken)
     {
         var now = _timeProvider.GetUtcNow();
-        State.PartyIdentifier.TryGetValue(out PersonIdentifier? personIdentifier);
 
-        Debug.Assert(personIdentifier is not null && personIdentifier == message.PersonIdentifier);
         State.Party = new PersonRecord
         {
             PartyUuid = FieldValue.Unset,

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportSirePartyCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.ImportSirePartyCommand.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Altinn.Authorization.ModelUtils;
 using Altinn.Register.Contracts;
 using Altinn.Register.Core.Parties.Records;
@@ -20,11 +19,12 @@ public partial class A2PartyImportSaga
 
     /// <inheritdoc/>
     public async Task Handle(ImportSirePartyCommand message, CancellationToken cancellationToken)
+        => await HandleImportSireParty(message.OrganizationIdentifier, cancellationToken);
+
+    private async Task HandleImportSireParty(OrganizationIdentifier organizationIdentifier, CancellationToken cancellationToken)
     {
         var now = _timeProvider.GetUtcNow();
-        State.PartyIdentifier.TryGetValue(out OrganizationIdentifier? organizationIdentifier);
 
-        Debug.Assert(organizationIdentifier is not null && organizationIdentifier == message.OrganizationIdentifier);
         State.Party = new OrganizationRecord
         {
             // party fields — placeholders, the enrichment chain fills these in

--- a/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.RetryA2PartyImportSagaCommand.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register/PartyImport/A2/A2PartyImportSaga.RetryA2PartyImportSagaCommand.cs
@@ -1,3 +1,6 @@
+using Altinn.Register.Core.Parties.Records;
+using CommunityToolkit.Diagnostics;
+
 namespace Altinn.Register.PartyImport.A2;
 
 /// <summary>
@@ -13,12 +16,34 @@ public partial class A2PartyImportSaga
             throw new InvalidOperationException("PartyIdentifier is not set");
         }
 
-        State.Clear();
-        if (await FetchPartyFromA2(cancellationToken) == FlowControl.Break)
+        if (State.Party is null)
         {
-            return;
+            throw new InvalidOperationException("Party is not set");
         }
 
-        await Enrich(cancellationToken);
+        switch (State.Party)
+        {
+            case OrganizationRecord org when org.Source.HasValue && org.Source.Value == Contracts.OrganizationSource.RegisteredWithSkatteetaten:
+                if (!State.PartyIdentifier.TryGetValue(out Contracts.OrganizationIdentifier? organizationIdentifier))
+                {
+                    ThrowHelper.ThrowInvalidOperationException("PartyIdentifier is not an organization identifier");
+                }
+
+                State.Clear();
+                await HandleImportSireParty(organizationIdentifier, cancellationToken);
+                return;
+
+            case PersonRecord person when person.Source.HasValue && person.Source.Value == Contracts.PersonSource.NationalPopulationRegister:
+                if (!State.PartyIdentifier.TryGetValue(out Contracts.PersonIdentifier? personIdentifier))
+                {
+                    ThrowHelper.ThrowInvalidOperationException("PartyIdentifier is not a person identifier");
+                }
+
+                State.Clear();
+                await HandleImportNprParty(personIdentifier, cancellationToken);
+                return;
+        }
+
+        ThrowHelper.ThrowInvalidOperationException("Party source is not set or not supported for retry");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved party-import retry handling by validating party details and supported sources before retrying.
  * Retry operations now preserve the correct person or organization identifier and provide clearer errors for unsupported or incomplete party data.

* **Refactor**
  * Streamlined person and organization import processing for more consistent handling of incoming identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->