### PR TITLE
fix: make tx_max_safeval cross-db safe

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.64-seq-lock-database/00-functions.sql
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Persistence/Migration/v0.64-seq-lock-database/00-functions.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION register.tx_max_safeval(
+  seq regclass
+)
+RETURNS bigint AS $$
+DECLARE
+  seq_id oid;
+  database_id oid;
+  max_seq bigint;
+BEGIN
+  -- Make sure seq is a sequence
+  SELECT "oid" INTO seq_id
+  FROM pg_class
+  WHERE "oid" = seq::oid AND "relkind" = 'S';
+
+  IF seq_id IS NULL THEN
+    RAISE EXCEPTION 'Relation %s is not a sequence', seq;
+  END IF;
+
+  SELECT "oid" INTO database_id
+  FROM pg_database
+  WHERE datname = current_database();
+
+  -- Find the minimum seq across all running transactions in the current database
+  -- note: we deal with two related locks here (correlated by pid and virtualtransaction)
+  -- one is to know we've locked on the sequence, and the other is to know what value
+  -- we've locked all values after
+  -- The first one (seq_lock) is a two-int advisory lock with classid = the oid of the sequence, objid = 0, and objsubid = 2
+  -- the second one (val_lock) is a bigint advisory lock split across classid and objid, with objsubid = 1
+  SELECT min((val_lock.classid::bigint << 32) | val_lock.objid::bigint) INTO max_seq
+  FROM pg_locks seq_lock
+  INNER JOIN pg_locks val_lock
+    ON  seq_lock.pid = val_lock.pid
+    AND seq_lock.virtualtransaction = val_lock.virtualtransaction
+    AND seq_lock.database = val_lock.database
+  WHERE seq_lock.database = database_id
+    AND seq_lock.classid = seq::oid
+    AND seq_lock.objid = 0
+    AND seq_lock.objsubid = 2
+    AND seq_lock.locktype = 'advisory'
+    AND seq_lock.granted
+    AND val_lock.objsubid = 1
+    AND val_lock.locktype = 'advisory'
+    AND val_lock.granted;
+
+  -- If no locks are found, return the maximum possible bigint value
+  IF max_seq IS NULL THEN
+      RETURN 9223372036854775807;
+  END IF;
+
+  -- Return the maximum safe value
+  RETURN max_seq;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
@@ -683,9 +683,15 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
         await using var otherConnection = new NpgsqlConnection(otherDatabase.ConnectionString);
         await otherConnection.OpenAsync(CancellationToken);
         await using var otherTransaction = await otherConnection.BeginTransactionAsync(CancellationToken);
-        await using var command = otherConnection.CreateCommand();
-        command.CommandText = /*strpsql*/"SELECT register.tx_nextval('register.party_version_id_seq')";
-        await command.ExecuteNonQueryAsync(CancellationToken);
+        await using var otherCommand = otherConnection.CreateCommand();
+        otherCommand.CommandText = /*strpsql*/"SELECT register.tx_nextval('register.party_version_id_seq')";
+        await otherCommand.ExecuteNonQueryAsync(CancellationToken);
+
+        await using var maxSafeValueCommand = Connection.CreateCommand();
+        maxSafeValueCommand.CommandText = /*strpsql*/"SELECT register.tx_max_safeval('register.party_version_id_seq')";
+        var maxSafeValue = (long)(await maxSafeValueCommand.ExecuteScalarAsync(CancellationToken))!;
+
+        maxSafeValue.ShouldBe(long.MaxValue);
 
         var items = await Persistence.GetPartyStream(0, 100, PartyFieldIncludes.Party, cancellationToken: CancellationToken).ToListAsync(CancellationToken);
 

--- a/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.Persistence.Tests/PostgreSqlPartyPersistenceTests.cs
@@ -676,6 +676,22 @@ public class PostgreSqlPartyPersistenceTests(ITestOutputHelper output)
         items.Count.ShouldBe(100);
     }
 
+    [Fact]
+    public async Task GetPartyStream_IgnoresSequenceLocksFromOtherDatabases()
+    {
+        await using var otherDatabase = await CreateDatabaseFromTemplate(CancellationToken);
+        await using var otherConnection = new NpgsqlConnection(otherDatabase.ConnectionString);
+        await otherConnection.OpenAsync(CancellationToken);
+        await using var otherTransaction = await otherConnection.BeginTransactionAsync(CancellationToken);
+        await using var command = otherConnection.CreateCommand();
+        command.CommandText = /*strpsql*/"SELECT register.tx_nextval('register.party_version_id_seq')";
+        await command.ExecuteNonQueryAsync(CancellationToken);
+
+        var items = await Persistence.GetPartyStream(0, 100, PartyFieldIncludes.Party, cancellationToken: CancellationToken).ToListAsync(CancellationToken);
+
+        items.Count.ShouldBe(100);
+    }
+
     #region Upsert Org
 
     [Fact]

--- a/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/DatabaseTestBase.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.TestUtils.V3/DatabaseTestBase.cs
@@ -15,6 +15,8 @@ public abstract class DatabaseTestBase
     : HostTestBase
 {
     private PostgresDatabase? _db;
+    private PostgresServerFixture? _serverFixture;
+    private PostgresServerFixture.TemplateDb? _template;
 
     /// <summary>
     /// Gets whether database seed data should be enabled.
@@ -32,6 +34,12 @@ public abstract class DatabaseTestBase
     protected RegisterTestDataGenerator TestDataGenerator => GetRequiredService<RegisterTestDataGenerator>();
 
     /// <summary>
+    /// Creates another uniquely named database from the same template as the per-test database.
+    /// </summary>
+    protected Task<PostgresDatabase> CreateDatabaseFromTemplate(CancellationToken cancellationToken = default)
+        => _serverFixture!.CreateDatabase(_template, cancellationToken);
+
+    /// <summary>
     /// Gets the application configuration.
     /// </summary>
     protected IConfigurationManager Configuration
@@ -41,12 +49,12 @@ public abstract class DatabaseTestBase
     protected override async ValueTask ConfigureHost(IHostApplicationBuilder builder)
     {
         var testContext = TestContext.Current;
-        var serverFixture = await testContext.GetRequiredFixture<PostgresServerFixture>();
-        var template = await serverFixture.GetOrCreateTemplateDatabase(
+        _serverFixture = await testContext.GetRequiredFixture<PostgresServerFixture>();
+        _template = await _serverFixture.GetOrCreateTemplateDatabase(
             "persistence-tests-template",
             InitializeTemplateDatabase,
             testContext.CancellationToken);
-        _db = await serverFixture.CreateDatabase(template, testContext.CancellationToken);
+        _db = await _serverFixture.CreateDatabase(_template, testContext.CancellationToken);
 
         await base.ConfigureHost(builder);
 


### PR DESCRIPTION
diff:

```diff
6a7
>   database_id oid;
18c19,23
<   -- Find the minimum seq across all running transactions
---
>   SELECT "oid" INTO database_id
>   FROM pg_database
>   WHERE datname = current_database();
>
>   -- Find the minimum seq across all running transactions in the current database
29c34,36
<   WHERE seq_lock.classid = seq::oid
---
>     AND seq_lock.database = val_lock.database
>   WHERE seq_lock.database = database_id
>     AND seq_lock.classid = seq::oid
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved party stream retrieval when sequence activity is occurring in another database.
  - Prevented unrelated database transactions from blocking or affecting party data reads.
  - Enhanced sequence safety checks to ensure values remain valid while concurrent transactions are active.

- **Tests**
  - Added coverage for cross-database transaction scenarios and sequence locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->