### PR TITLE
fix: return correct party name for email users in legacy API

### DIFF
--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyById.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyById.cs
@@ -50,7 +50,7 @@ internal sealed class GetV1PartyByIdFromDBRequestHandler(IUnitOfWorkManager mana
         var persistence = uow.GetPartyPersistence();
 
         var party = await persistence
-            .GetPartyById(request.PartyId, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User, cancellationToken)
+            .GetPartyById(request.PartyId, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User | PartyFieldIncludes.SelfIdentifiedUser, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (party is null)

--- a/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyByUuid.cs
+++ b/src/apps/Altinn.Register/src/Altinn.Register.Core/Operations/GetV1PartyByUuid.cs
@@ -50,7 +50,7 @@ internal sealed class GetV1PartyByUuidFromDBRequestHandler(IUnitOfWorkManager ma
         var persistence = uow.GetPartyPersistence();
 
         var party = await persistence
-            .GetPartyById(request.PartyUuid, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User, cancellationToken)
+            .GetPartyById(request.PartyUuid, PartyFieldIncludes.Party | PartyFieldIncludes.Person | PartyFieldIncludes.Organization | PartyFieldIncludes.User | PartyFieldIncludes.SelfIdentifiedUser, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (party is null)

--- a/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/PartiesControllerTests.cs
+++ b/src/apps/Altinn.Register/test/Altinn.Register.IntegrationTests/Controllers/PartiesControllerTests.cs
@@ -326,8 +326,11 @@ public class PartiesControllerTests
     [CombinatorialData]
     public async Task GetPartyByUuid_ValidTokenRequestForExistingSelfIdentifiedUser_ReturnsParty(TestApiSource source)
     {
-        var siUser = await Setup((uow, ct) => uow.CreateSelfIdentifiedUser(cancellationToken: ct));
-        var expectedName = V1PartyMapper.ToV1Party(siUser).Name;
+        const string email = "idporten-email-user@example.com";
+        var siUser = await Setup((uow, ct) => uow.CreateSelfIdentifiedUser(
+            type: SelfIdentifiedUserType.IdPortenEmail,
+            email: email,
+            cancellationToken: ct));
 
         SetSource(source);
         if (source == TestApiSource.A2)
@@ -351,7 +354,7 @@ public class PartiesControllerTests
             (Contracts.V1.Party p) => p.PartyId.ShouldBe((int)siUser.PartyId.Value),
             (Contracts.V1.Party p) => p.PartyUuid.ShouldBe(siUser.PartyUuid.Value),
             (Contracts.V1.Party p) => p.PartyTypeName.ShouldBe(Contracts.V1.PartyType.SelfIdentified),
-            (Contracts.V1.Party p) => p.Name.ShouldBe(expectedName),
+            (Contracts.V1.Party p) => p.Name.ShouldBe($"epost:{email}"),
             (Contracts.V1.Party p) => p.Person.ShouldBeNull(),
             (Contracts.V1.Party p) => p.Organization.ShouldBeNull(),
         ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Party lookups now include self-identified user information.
  * Self-identified users are returned with the expected party name format.
* **Tests**
  * Updated integration coverage to verify party names for email-based self-identified users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->